### PR TITLE
Provisioning seam: let apps populate their own user columns at signup

### DIFF
--- a/crudauth/__init__.py
+++ b/crudauth/__init__.py
@@ -34,6 +34,7 @@ from .crud_auth import CRUDAuth
 from .hooks import AuthHooks, HookContext
 from .oauth import OAuthCredentials
 from .principal import Principal
+from .provisioning import NewUserContext, NewUserFields
 from .sudo import SudoConfig
 from .transports import BearerTransport, SessionTransport
 
@@ -50,6 +51,8 @@ __all__ = [
     "EmailSender",
     "AuthHooks",
     "HookContext",
+    "NewUserContext",
+    "NewUserFields",
     "Transport",
     "AuthContext",
     "CookieConfig",

--- a/crudauth/crud_auth.py
+++ b/crudauth/crud_auth.py
@@ -41,6 +41,7 @@ from .hooks import AuthHooks
 from .oauth import OAuthAccountService, OAuthProviderFactory
 from .oauth.router import build_oauth_router
 from .principal import Principal
+from .provisioning import NewUserFields
 from .ratelimit import (
     DEFAULT_RATE_LIMITS,
     KeyBy,
@@ -105,6 +106,8 @@ class CRUDAuth:
         cookies: CookieConfig | None = None,
         register_schema: type[BaseModel] | None = None,
         register_extra_fields: set[str] | None = None,
+        new_user_fields: NewUserFields | None = None,
+        new_user_defaults: dict[str, Any] | None = None,
         rate_limiter: "RateLimiterBackend | None" = None,
         rate_limits: dict[str, RateLimit] | None = None,
         trusted_proxy_hops: int = 0,
@@ -143,6 +146,22 @@ class CRUDAuth:
                 so adding a column to your model never silently becomes settable
                 at signup. crudauth's privileged fields (``is_superuser``,
                 ``email_verified``, ...) can never be opted in.
+            new_user_defaults: Constant app columns to set on every new user, on
+                BOTH ``/register`` and OAuth signup (e.g. ``{"tier_id": FREE}``).
+                The declarative shortcut for fixed values; gated like
+                ``new_user_fields`` (a crudauth-owned key is dropped + warned at
+                construction).
+            new_user_fields: Callback (sync or async) returning extra columns to
+                set when crudauth creates a user, for values that must be
+                *derived* (and may read the DB) rather than constant - e.g.
+                ``lambda ctx: {"name": ctx.suggested_name}``. Receives a trusted
+                [NewUserContext][crudauth.provisioning.NewUserContext] (never the
+                request body) and returns app columns only, as a ``dict`` or a
+                ``BaseModel``; any crudauth logical field it returns is dropped
+                (crudauth stays authoritative). Merged into the single insert
+                after ``new_user_defaults``, so a derived value can override a
+                constant default. Client-typed fields belong in ``register_schema``
+                /``register_extra_fields``, not here.
             rate_limiter: Backend for lockout/throttles; defaults to an in-process
                 [MemoryRateLimiterBackend][crudauth.ratelimit.backends.memory.MemoryRateLimiterBackend]. Use
                 ``redis_rate_limiter(...)`` in production.
@@ -174,6 +193,8 @@ class CRUDAuth:
             raise ValueError("SECRET_KEY is required")
         self.session = session
         self.repo = UserRepository(user_model, column_map, register_extra_fields)
+        self.new_user_fields = new_user_fields
+        self._new_user_defaults = self.repo.filter_provisioning_data(new_user_defaults or {})
         self.hooks = hooks or AuthHooks()
         self.transports: list[Transport] = list(transports) if transports else [SessionTransport()]
         self._register_schema = register_schema
@@ -391,7 +412,9 @@ class CRUDAuth:
             runtime=self.runtime,
             providers=providers,
             state_storage=state_storage,
-            account_service=OAuthAccountService(self.repo),
+            account_service=OAuthAccountService(
+                self.repo, self.new_user_fields, self._new_user_defaults
+            ),
             session_manager=self.sessions,
             default_redirect=redirect_base_url,
         )
@@ -669,6 +692,14 @@ class CRUDAuth:
                 already has a usable password (use the password-reset flow to
                 change an existing one). It does not evict other sessions/tokens
                 (establishing a first credential isn't a compromise response).
+
+            Note:
+                Allowed over any transport. On the session path the POST already
+                carries CSRF; on the bearer path there's no CSRF surface (the
+                token is sent explicitly, not auto-attached), and a valid bearer
+                token is itself proof of the active credential - the same re-auth
+                argument. Narrow with ``transport="session"`` if your policy
+                requires first-password establishment to be browser-only.
             """
             user = principal.user
             if not is_unusable_password(self.repo.get(user, "hashed_password", "")):

--- a/crudauth/oauth/service.py
+++ b/crudauth/oauth/service.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..exceptions import BadRequestException
+from ..provisioning import NewUserContext, NewUserFields, resolve_new_user_fields
 from ..repository import UserRepository
 from ..utils import canonical_email, make_unusable_password
 from .constants import (
@@ -37,8 +38,15 @@ def _sanitize_username(raw: str) -> str:
 
 
 class OAuthAccountService:
-    def __init__(self, repo: UserRepository):
+    def __init__(
+        self,
+        repo: UserRepository,
+        new_user_fields: NewUserFields | None = None,
+        new_user_defaults: dict[str, Any] | None = None,
+    ):
         self.repo = repo
+        self.new_user_fields = new_user_fields
+        self.new_user_defaults = new_user_defaults or {}
 
     async def get_or_create_user(self, info: OAuthUserInfo, db: AsyncSession) -> tuple[Any, bool]:
         """Resolve an OAuth identity to a user; lookup order: provider id → email → create.
@@ -117,6 +125,21 @@ class OAuthAccountService:
             "oauth_created_at": now,
             "oauth_updated_at": now,
         }
+        data.update(self.new_user_defaults)
+        data.update(
+            await resolve_new_user_fields(
+                self.new_user_fields,
+                NewUserContext(
+                    email=data["email"],
+                    username=data["username"],
+                    source="oauth",
+                    db=db,
+                    register_data=None,
+                    oauth=info,
+                ),
+                self.repo,
+            )
+        )
         try:
             return await self.repo.create(db, data)
         except IntegrityError:

--- a/crudauth/provisioning.py
+++ b/crudauth/provisioning.py
@@ -1,0 +1,96 @@
+"""App-supplied fields for new-user creation (server-side, both signup paths).
+
+crudauth inserts the user row itself, on ``/register`` and on OAuth signup, from
+the logical fields it owns (``email``, ``username``, ``hashed_password``, the
+oauth linkage). A real app's user table is usually wider than that contract and
+often has columns that are ``NOT NULL`` with no default (``name``, ``tier_id``,
+...). ``new_user_fields`` is the seam that lets the app contribute those columns
+to the same insert, on both signup paths, without crudauth dictating the model's
+shape.
+
+The callback is fed a *trusted* [NewUserContext][crudauth.provisioning.NewUserContext]
+that crudauth builds - never the raw request body, so a client can't smuggle a
+column value through it. It returns app columns only (as a ``dict`` or a
+``BaseModel``): any crudauth logical field it tries to set (by logical or mapped
+column name) is dropped, so it can fill the app's own columns but never override
+identity, privilege, or state crudauth is authoritative for. See
+[UserRepository.filter_provisioning_data][crudauth.repository.UserRepository.filter_provisioning_data].
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Literal, Union
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from .oauth.schemas import OAuthUserInfo
+    from .repository import UserRepository
+
+__all__ = ["NewUserContext", "NewUserFields", "resolve_new_user_fields"]
+
+
+@dataclass(frozen=True)
+class NewUserContext:
+    """What crudauth knows about a user it is about to create.
+
+    Fed to ``new_user_fields`` on both signup paths. Server-built and trusted -
+    never the raw request body.
+
+    Attributes:
+        email: The new user's (canonicalized) email.
+        username: The final username, after OAuth uniquification.
+        source: ``"register"`` for password signup, ``"oauth"`` for OAuth signup.
+        db: The active session. The callback may read from it (e.g. to resolve a
+            default tier or assign an org by email domain) but must NOT commit -
+            crudauth owns the transaction boundary.
+        register_data: The validated ``/register`` body (password excluded), or
+            ``None`` on the OAuth path.
+        oauth: The provider profile, or ``None`` on the password path.
+    """
+
+    email: str
+    username: str
+    source: Literal["register", "oauth"]
+    db: AsyncSession
+    register_data: dict[str, Any] | None = None
+    oauth: OAuthUserInfo | None = None
+
+    @property
+    def suggested_name(self) -> str:
+        """A display name to default to: the OAuth name if present, else the
+        email local-part."""
+        if self.oauth is not None and self.oauth.name:
+            return self.oauth.name
+        return self.email.split("@")[0]
+
+
+NewUserFields = Callable[
+    [NewUserContext], Union[BaseModel, dict[str, Any], Awaitable[Union[BaseModel, dict[str, Any]]]]
+]
+
+
+async def resolve_new_user_fields(
+    callback: NewUserFields | None,
+    context: NewUserContext,
+    repo: UserRepository,
+) -> dict[str, Any]:
+    """Run ``callback`` (sync or async), normalize its return, and gate it.
+
+    Returns an empty dict when ``callback`` is ``None``. A returned ``BaseModel``
+    is ``model_dump()``-ed first, then the dict is filtered through
+    [filter_provisioning_data][crudauth.repository.UserRepository.filter_provisioning_data]
+    so a typed field naming a crudauth column is dropped exactly like a dict key.
+    """
+    if callback is None:
+        return {}
+    result = callback(context)
+    if inspect.isawaitable(result):
+        result = await result
+    data = result.model_dump() if isinstance(result, BaseModel) else dict(result)
+    return repo.filter_provisioning_data(data)

--- a/crudauth/register/route.py
+++ b/crudauth/register/route.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import IntegrityError
 from ..constants import MIN_PASSWORD_LENGTH
 from ..exceptions import DuplicateValueException
 from ..hooks import HookContext
+from ..provisioning import NewUserContext, resolve_new_user_fields
 from ..ratelimit import KeyBy
 from ..utils import get_client_ip, get_password_hash
 
@@ -88,6 +89,7 @@ def build_register_route(auth: Any, schema: type[BaseModel] | None) -> APIRouter
         email_on = auth._email_service is not None
         data = cast(BaseModel, body).model_dump()
         password = data.pop("password")
+        submitted = dict(data)
         data = auth.repo.filter_registration_data(data)
         email = data.pop("email")
         username = data.pop("username")
@@ -135,6 +137,21 @@ def build_register_route(auth: Any, schema: type[BaseModel] | None) -> APIRouter
             "hashed_password": get_password_hash(password),
         }
         create_data.update(data)
+        create_data.update(auth._new_user_defaults)
+        create_data.update(
+            await resolve_new_user_fields(
+                auth.new_user_fields,
+                NewUserContext(
+                    email=email,
+                    username=username,
+                    source="register",
+                    db=db,
+                    register_data=submitted,
+                    oauth=None,
+                ),
+                auth.repo,
+            )
+        )
 
         try:
             user = await auth.repo.create(db, create_data)

--- a/crudauth/repository.py
+++ b/crudauth/repository.py
@@ -8,6 +8,7 @@ schema to adopt the library.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 from typing import Any
 
@@ -20,6 +21,8 @@ from .constants import (
     REGISTRATION_GATED_FIELDS,
 )
 from .utils import canonical_email
+
+logger = logging.getLogger("crudauth")
 
 __all__ = [
     "UserRepository",
@@ -42,6 +45,7 @@ class UserRepository:
         self.model = model
         self.column_map = column_map or {}
         self.register_extra_fields = frozenset(register_extra_fields or ())
+        self._warned_provisioning_keys: set[str] = set()
 
     # --- contract translation ------------------------------------------------
     def col(self, logical: str) -> str:
@@ -193,6 +197,41 @@ class UserRepository:
         allowed = self._allowed_register_names()
         gated = self._gated_names()
         return {k: v for k, v in data.items() if k in allowed and k not in gated}
+
+    def _contract_names(self) -> set[str]:
+        """Every crudauth logical field, by logical AND mapped column name."""
+        return set(LOGICAL_FIELDS) | {self.col(f) for f in LOGICAL_FIELDS}
+
+    def filter_provisioning_data(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Keep only app columns from a ``new_user_fields`` callback.
+
+        Drops any key that is a crudauth logical field (by logical *or* mapped
+        column name) and logs a warning, so the callback can fill the app's own
+        columns at signup but can never override identity, privilege, or state
+        crudauth owns (``email``, ``hashed_password``, ``is_superuser``,
+        ``email_verified``, the oauth linkage, the PK). The dropped key keeps
+        crudauth's authoritative value.
+
+        Note:
+            The callback runs per signup, so a misconfigured one would drop the
+            same key on every registration. Each distinct dropped field is warned
+            only ONCE per process (deduped across the constant ``new_user_defaults``
+            and the runtime callback) so a standing misconfiguration can't flood
+            the logs.
+        """
+        contract = self._contract_names()
+        kept = {k: v for k, v in data.items() if k not in contract}
+        new_drops = sorted(
+            k for k in data if k in contract and k not in self._warned_provisioning_keys
+        )
+        if new_drops:
+            self._warned_provisioning_keys.update(new_drops)
+            logger.warning(
+                "crudauth: new_user_fields tried to set crudauth-owned field(s) %s; "
+                "dropped (crudauth's value is authoritative). Return only app columns.",
+                new_drops,
+            )
+        return kept
 
     # --- writes --------------------------------------------------------------
     async def create(self, db: AsyncSession, data: dict[str, Any]) -> Any:

--- a/docs/api/provisioning.md
+++ b/docs/api/provisioning.md
@@ -1,0 +1,9 @@
+# Provisioning
+
+App-supplied columns for new-user creation. `new_user_fields` on [CRUDAuth](crud-auth.md)
+receives this context and returns your own columns to set at signup, on both the password and
+OAuth paths; `new_user_defaults` is the constant-only shortcut. See the
+[registration guide](../guides/accounts/registration.md#setting-columns-the-server-controls)
+for usage.
+
+::: crudauth.provisioning.NewUserContext

--- a/docs/guides/accounts/registration.md
+++ b/docs/guides/accounts/registration.md
@@ -51,6 +51,36 @@ A field declared in the schema but not opted into `register_extra_fields` is dro
 startup warning). CRUDAuth's privileged fields (`is_superuser`, `email_verified`, ...) can
 **never** be opted in; declaring one is logged and ignored.
 
+## Setting columns the server controls
+
+`register_extra_fields` is for fields the *client* sends. For columns the *server* fills,
+especially ones that are `NOT NULL` with no default, or values you derive, use
+`new_user_defaults` (constants) or `new_user_fields` (a callback). Both run wherever CRUDAuth
+creates a user: `/register` **and** OAuth signup.
+
+```python
+# constant values
+auth = CRUDAuth(..., new_user_defaults={"tier_id": FREE_TIER_ID})
+
+# derived values (sync or async; the callback may read the database)
+def new_user_fields(ctx):
+    return {"name": ctx.suggested_name, "tier_id": FREE_TIER_ID}
+
+auth = CRUDAuth(..., new_user_fields=new_user_fields)
+```
+
+The callback gets a [`NewUserContext`](../../api/provisioning.md): `email`, `username`,
+`source` (`"register"` or `"oauth"`), the live `db`, the validated `register_data`, and the
+`oauth` profile, so you can branch on the path or derive from the provider. `ctx.suggested_name`
+is the OAuth display name, with the email local-part as a fallback. Return a dict or a Pydantic
+model.
+
+The difference from `register_extra_fields` is the trust boundary: this is fed a server-built
+context, never the request body, so a client can't set these values. `new_user_defaults` merges
+first, then `new_user_fields`, so a derived value can override a constant. Both are gated like
+the allowlist: a CRUDAuth-owned field (`is_superuser`, `email_verified`, the password, the oauth
+ids, the PK) is dropped and warned, never set.
+
 ## Duplicate emails
 
 Registering with an address that already exists returns the same generic response as a new

--- a/docs/guides/auth/oauth.md
+++ b/docs/guides/auth/oauth.md
@@ -45,7 +45,9 @@ On a successful callback, CRUDAuth finds or creates the user:
 - If a user already exists with the provider's verified email, the provider account is linked
   to it (the `{provider}_id` column is set). The user can then sign in by password or by that
   provider.
-- Otherwise a new user is created from the provider profile.
+- Otherwise a new user is created from the provider profile. To set your own columns on that
+  user (a required `name`, a default tier), use `new_user_fields` / `new_user_defaults`, which
+  run on this path too; see [Registration](../accounts/registration.md#setting-columns-the-server-controls).
 
 ## Custom providers
 

--- a/docs/learn/3-modeling-your-user.md
+++ b/docs/learn/3-modeling-your-user.md
@@ -89,6 +89,25 @@ The allowlist is the whole point: adding `locale` to your model doesn't quietly 
 
 To change the request body itself (different validation rules, extra required inputs), pass your own Pydantic model as `register_schema`. The allowlist still applies on top: a field in your schema is persisted only if it's `email`, `username`, or opted into `register_extra_fields`.
 
+## Filling columns the server owns
+
+The columns you added earlier were safe to leave out at signup: `full_name` is nullable, `locale` has a default. Add a *required* column with no default, say `name: Mapped[str]`, and signup breaks: CRUDAuth builds the new row from the fields it knows (email, username, password), and your `NOT NULL` `name` isn't one of them.
+
+`register_extra_fields` doesn't solve this on its own. It lets the *client* send `name`; it doesn't let the *server* set one, and it does nothing for the OAuth path, which has no form at all. For server-owned values, constant or derived, there's a separate seam:
+
+```python
+# a constant for everyone
+auth = CRUDAuth(..., new_user_defaults={"tier_id": FREE})
+
+# or derive it
+def new_user_fields(ctx):
+    return {"name": ctx.suggested_name}
+
+auth = CRUDAuth(..., new_user_fields=new_user_fields)
+```
+
+This runs wherever CRUDAuth creates a user, password and OAuth alike, and it's fed a trusted context (the email, the OAuth profile, the database), never the request body. That's chapter 1's mass-assignment lesson again: the client decides what the client may send, the server decides what the server sets, and the two never blur. A privileged field returned here is dropped, the same way it is at the registration allowlist.
+
 ## Where this leaves you
 
 The model is yours: the mixin supplies the auth columns (or `column_map` points at the ones you have), your own columns ride alongside untouched, and registration can set only what you've explicitly allowed. Auth touches a known, small slice of the row, and nothing else.

--- a/tests/test_new_user_fields.py
+++ b/tests/test_new_user_fields.py
@@ -1,0 +1,373 @@
+"""``new_user_fields``: app-supplied columns merged into the single create on
+both signup paths (register + oauth), gated so the callback can fill app columns
+but never override crudauth's logical contract."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sqlalchemy import func, select
+
+from crudauth import CookieConfig, CRUDAuth, NewUserContext, NewUserFields, SessionTransport
+from crudauth.oauth import OAuthAccountService, OAuthUserInfo
+from crudauth.repository import UserRepository
+
+SECRET = "test-secret-key-0123456789-0123456789"
+
+
+# --- unit: the gating helper ---------------------------------------------
+
+
+def test_filter_provisioning_keeps_app_columns_drops_contract(UserModel, caplog) -> None:
+    repo = UserRepository(UserModel)
+    with caplog.at_level(logging.WARNING, logger="crudauth"):
+        out = repo.filter_provisioning_data(
+            {
+                "full_name": "A",  # app column -> kept
+                "role": "staff",  # app column -> kept
+                "email": "x@y.com",  # contract -> dropped
+                "hashed_password": "h",  # contract -> dropped
+                "is_superuser": True,  # contract -> dropped
+                "id": 9,  # contract -> dropped
+            }
+        )
+    assert out == {"full_name": "A", "role": "staff"}
+    assert "new_user_fields" in caplog.text
+    assert "is_superuser" in caplog.text
+
+
+def test_filter_provisioning_warns_once_per_key(UserModel, caplog) -> None:
+    # A standing misconfiguration (same gated key dropped every signup) must not
+    # flood the logs: warn once per distinct key, then stay quiet.
+    repo = UserRepository(UserModel)
+    with caplog.at_level(logging.WARNING, logger="crudauth"):
+        repo.filter_provisioning_data({"is_superuser": True, "role": "a"})
+        repo.filter_provisioning_data({"is_superuser": True, "role": "b"})  # same key again
+    assert caplog.text.count("new_user_fields") == 1  # only the first drop warned
+    # a *different* gated key still warns (it's new)
+    with caplog.at_level(logging.WARNING, logger="crudauth"):
+        caplog.clear()
+        repo.filter_provisioning_data({"email_verified": True})
+    assert "email_verified" in caplog.text
+
+
+def test_filter_provisioning_respects_column_map(UserModel) -> None:
+    # is_superuser aliased to is_admin: returning the mapped name is dropped too,
+    # closing the alias hole.
+    repo = UserRepository(UserModel, column_map={"is_superuser": "is_admin"})
+    out = repo.filter_provisioning_data({"is_admin": True, "role": "staff"})
+    assert out == {"role": "staff"}
+
+
+# --- register path --------------------------------------------------------
+
+
+async def _register(
+    get_session,
+    UserModel,
+    callback: NewUserFields | None,
+    defaults: dict[str, Any] | None = None,
+) -> httpx.Response:
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=UserModel,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        new_user_fields=callback,
+        new_user_defaults=defaults,
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+    await auth.initialize()
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            return await c.post(
+                "/register",
+                json={"email": "new@x.com", "username": "new", "password": "pw123456"},
+            )
+    finally:
+        await auth.shutdown()
+
+
+async def test_register_runs_callback_and_sets_app_columns(
+    get_session, UserModel, sessionmaker
+) -> None:
+    seen: list[NewUserContext] = []
+
+    def fields(ctx: NewUserContext) -> dict[str, Any]:
+        seen.append(ctx)
+        return {"full_name": ctx.email.split("@")[0], "role": "staff"}
+
+    r = await _register(get_session, UserModel, fields)
+    assert r.status_code == 200, r.text
+
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.full_name == "new"
+    assert user.role == "staff"
+
+    assert seen[0].source == "register"
+    assert seen[0].oauth is None
+    body = seen[0].register_data
+    assert body is not None and body["username"] == "new" and "password" not in body
+
+
+async def test_register_callback_cannot_override_contract(
+    get_session, UserModel, sessionmaker, caplog
+) -> None:
+    def fields(ctx: NewUserContext) -> dict[str, Any]:
+        return {
+            "role": "staff",
+            "is_superuser": True,
+            "email_verified": True,
+            "email": "evil@x.com",
+        }
+
+    with caplog.at_level(logging.WARNING, logger="crudauth"):
+        r = await _register(get_session, UserModel, fields)
+    assert r.status_code == 200, r.text
+
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.role == "staff"  # app column set
+    assert user.is_superuser is False  # contract field NOT overridden
+    assert user.email_verified is False
+    assert user.email == "new@x.com"  # not the callback's "evil@x.com"
+    assert "new_user_fields" in caplog.text
+
+
+async def test_register_async_callback(get_session, UserModel, sessionmaker) -> None:
+    async def fields(ctx: NewUserContext) -> dict[str, Any]:
+        return {"role": "async-set"}
+
+    r = await _register(get_session, UserModel, fields)
+    assert r.status_code == 200, r.text
+
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.role == "async-set"
+
+
+async def test_register_without_callback_uses_model_defaults(
+    get_session, UserModel, sessionmaker
+) -> None:
+    r = await _register(get_session, UserModel, None)
+    assert r.status_code == 200, r.text
+
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.role == "user"  # the column default, untouched
+    assert user.full_name is None
+
+
+# --- oauth path -----------------------------------------------------------
+
+
+async def test_oauth_signup_runs_callback(sessionmaker, UserModel) -> None:
+    seen: list[NewUserContext] = []
+
+    def fields(ctx: NewUserContext) -> dict[str, Any]:
+        seen.append(ctx)
+        assert ctx.oauth is not None
+        return {"role": "oauth-user", "full_name": ctx.oauth.name}
+
+    repo = UserRepository(UserModel)
+    service = OAuthAccountService(repo, fields)
+    info = OAuthUserInfo(
+        provider="google",
+        provider_user_id="g-1",
+        email="o@x.com",
+        email_verified=True,
+        name="O Person",
+    )
+    async with sessionmaker() as db:
+        user, created = await service.get_or_create_user(info, db)
+    assert created is True
+    assert repo.get(user, "role") == "oauth-user"
+    assert repo.get(user, "full_name") == "O Person"
+
+    assert seen[0].source == "oauth"
+    assert seen[0].register_data is None
+    o = seen[0].oauth
+    assert o is not None and o.provider == "google"
+
+
+async def test_oauth_link_existing_skips_callback(sessionmaker, UserModel) -> None:
+    from crudauth.utils import get_password_hash
+
+    calls: list[NewUserContext] = []
+
+    def fields(ctx: NewUserContext) -> dict[str, Any]:
+        calls.append(ctx)
+        return {"role": "should-not-apply"}
+
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        await repo.create(
+            db,
+            {"email": "dup@x.com", "username": "dup", "hashed_password": get_password_hash("pw")},
+        )
+
+    service = OAuthAccountService(repo, fields)
+    info = OAuthUserInfo(
+        provider="github", provider_user_id="gh-9", email="dup@x.com", email_verified=True
+    )
+    async with sessionmaker() as db:
+        user, created = await service.get_or_create_user(info, db)
+    assert created is False  # linked, not created
+    assert repo.get(user, "role") == "user"  # callback never ran
+    assert calls == []
+
+
+# --- new_user_defaults (the declarative constant knob) --------------------
+
+
+def test_defaults_gated_at_construction(get_session, UserModel, caplog) -> None:
+    # A crudauth-owned key in the constants is dropped + warned ONCE, at build time.
+    with caplog.at_level(logging.WARNING, logger="crudauth"):
+        auth = CRUDAuth(
+            session=get_session,
+            user_model=UserModel,
+            SECRET_KEY=SECRET,
+            transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+            new_user_defaults={"role": "staff", "is_superuser": True},
+        )
+    assert auth._new_user_defaults == {"role": "staff"}  # is_superuser dropped
+    assert "new_user_fields" in caplog.text
+
+
+async def test_register_applies_defaults(get_session, UserModel, sessionmaker) -> None:
+    r = await _register(get_session, UserModel, None, defaults={"role": "from-defaults"})
+    assert r.status_code == 200, r.text
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.role == "from-defaults"
+
+
+async def test_callback_overrides_defaults(get_session, UserModel, sessionmaker) -> None:
+    def fields(ctx: NewUserContext) -> dict[str, Any]:
+        return {"role": "from-callback"}
+
+    r = await _register(get_session, UserModel, fields, defaults={"role": "from-defaults"})
+    assert r.status_code == 200, r.text
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.role == "from-callback"  # callback merged after defaults
+
+
+# --- BaseModel return + ctx.db + suggested_name ---------------------------
+
+
+async def test_callback_can_return_basemodel(get_session, UserModel, sessionmaker) -> None:
+    class Provision(BaseModel):
+        role: str = "from-model"
+        is_superuser: bool = True  # contract field on the model -> dropped after dump
+
+    def fields(ctx: NewUserContext) -> BaseModel:
+        return Provision()
+
+    r = await _register(get_session, UserModel, fields)
+    assert r.status_code == 200, r.text
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.role == "from-model"
+    assert user.is_superuser is False  # typed contract field still gated
+
+
+async def test_callback_can_read_ctx_db(get_session, UserModel, sessionmaker) -> None:
+    # The first-registered user becomes the owner, decided by a live query on ctx.db.
+    async def fields(ctx: NewUserContext) -> dict[str, Any]:
+        existing = await ctx.db.scalar(select(func.count()).select_from(UserModel))
+        return {"role": "owner" if existing == 0 else "member"}
+
+    r = await _register(get_session, UserModel, fields)
+    assert r.status_code == 200, r.text
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.role == "owner"
+
+
+async def test_suggested_name(sessionmaker) -> None:
+    async with sessionmaker() as db:
+        info = OAuthUserInfo(
+            provider="google", provider_user_id="g", email="a@x.com", name="Full Name"
+        )
+        oauth_ctx = NewUserContext(email="a@x.com", username="a", source="oauth", db=db, oauth=info)
+        assert oauth_ctx.suggested_name == "Full Name"
+        reg_ctx = NewUserContext(email="alice@x.com", username="a", source="register", db=db)
+        assert reg_ctx.suggested_name == "alice"
+
+
+# --- mass-assignment: neither knob can grant privilege, on either path ----
+
+
+async def test_defaults_cannot_grant_privilege_on_register(
+    get_session, UserModel, sessionmaker
+) -> None:
+    r = await _register(
+        get_session,
+        UserModel,
+        None,
+        defaults={"role": "staff", "is_superuser": True, "email_verified": True},
+    )
+    assert r.status_code == 200, r.text
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "new@x.com")
+    assert user is not None
+    assert user.role == "staff"
+    assert user.is_superuser is False
+    assert user.email_verified is False
+
+
+async def test_callback_cannot_grant_privilege_on_oauth(sessionmaker, UserModel) -> None:
+    def fields(ctx: NewUserContext) -> dict[str, Any]:
+        return {"role": "staff", "is_superuser": True, "email_verified": False}
+
+    repo = UserRepository(UserModel)
+    service = OAuthAccountService(repo, fields)
+    info = OAuthUserInfo(
+        provider="google", provider_user_id="g-2", email="ev@x.com", email_verified=True, name="Ev"
+    )
+    async with sessionmaker() as db:
+        user, created = await service.get_or_create_user(info, db)
+    assert created is True
+    assert repo.get(user, "role") == "staff"
+    assert repo.is_superuser(user) is False
+    assert (
+        repo.email_verified(user) is True
+    )  # crudauth's value (provider-verified), not the callback's
+
+
+async def test_oauth_applies_defaults(sessionmaker, UserModel) -> None:
+    repo = UserRepository(UserModel)
+    service = OAuthAccountService(repo, None, {"role": "oauth-default"})
+    info = OAuthUserInfo(
+        provider="github", provider_user_id="gh-1", email="d@x.com", email_verified=True
+    )
+    async with sessionmaker() as db:
+        user, created = await service.get_or_create_user(info, db)
+    assert created is True
+    assert repo.get(user, "role") == "oauth-default"

--- a/zensical.toml
+++ b/zensical.toml
@@ -126,6 +126,7 @@ edit_uri = "edit/main/docs/"
     { "OAuth" = "api/oauth.md" },
     { "Email" = "api/email.md" },
     { "Hooks" = "api/hooks.md" },
+    { "Provisioning" = "api/provisioning.md" },
     { "Sudo" = "api/sudo.md" },
     { "UserRepository" = "api/repository.md" },
     { "Models" = "api/models.md" },


### PR DESCRIPTION
# Provisioning seam: let apps populate their own user columns at signup

crudauth creates the user row itself on both signup paths, `/register` and OAuth, from only the fields it owns. Any required app column with no default breaks that insert, on both paths, and there was no way for the app to contribute its own columns. This branch adds a server-side provisioning seam: `new_user_defaults` for constant columns and `new_user_fields` for derived ones, both merged into the same insert and gated so they can fill the app's columns but never override crudauth's identity, privilege, or state. It is fully additive: existing setups behave exactly as before.

---

## The problem: crudauth owns user creation

`UserRepository.create` builds `self.model(**kwargs)` from only the logical fields crudauth knows: `email`, `username`, `hashed_password`, and the OAuth linkage. That is fine when every other column on the app's `User` is nullable or defaulted. It breaks the moment a real app adds a column that is `NOT NULL` with no default (or, on a `MappedAsDataclass` model, a required `__init__` argument): `User(email=..., username=..., hashed_password=...)` fails because the app's `name` isn't among the supplied fields. It fails identically on the password and OAuth paths, since both build their insert dict from the same contract.

The existing `register_extra_fields` knob does not close this. It allowlists fields the *client* sends in the register body, so it does nothing for OAuth (there is no body) and nothing for values the server computes (a default tier, a `name` derived from the email). The library could only create users against a model shaped like its own.

---

## The provisioning seam

Two new optional `CRUDAuth` constructor arguments fill the gap. `new_user_defaults` is a dict of constant columns; `new_user_fields` is a callback for values that must be derived. Both run wherever crudauth creates a user, on `/register` and OAuth signup alike, and merge into the single insert.

```python
# constant for everyone
auth = CRUDAuth(..., new_user_defaults={"tier_id": FREE_TIER_ID})

# derived per signup (sync or async; may read the DB)
def new_user_fields(ctx):
    return {"name": ctx.suggested_name, "tier_id": FREE_TIER_ID}

auth = CRUDAuth(..., new_user_fields=new_user_fields)
```

The callback receives a `NewUserContext` (a frozen dataclass) carrying `email`, `username`, `source` (`"register"` or `"oauth"`), the live `db` session, the validated `register_data` on the password path, and the `oauth` provider profile on the OAuth path, so it can branch on the path or derive from the provider. A `suggested_name` property returns the OAuth display name, falling back to the email local-part. The callback may be sync or async, may read the database through `ctx.db` (for example to resolve a default tier or assign an org by email domain), and may return either a plain dict or a Pydantic model, which crudauth dumps structurally. Merge order is defaults first, then the callback, so a derived value can override a constant default when the app wants it to.

**Why a callback rather than a schema:** values often need to be derived from per-signup inputs (a `name` from the email or the OAuth profile) or resolved from the database, neither of which a static schema or a field default can express. A Pydantic model is accepted as the *return* type for the typed, declarative surface, but the input is always the trusted context, never a model bound to the request body.

---

## Server-side trust boundary and gating

The seam is fed a context crudauth builds, never the raw request body. That is the load-bearing security property: a client cannot smuggle a value through `new_user_fields`, because the client never feeds it. Client-typed fields stay in `register_schema` / `register_extra_fields`; server-set fields go here; the two trust domains do not blur.

Whatever the seam returns is gated by a new `UserRepository.filter_provisioning_data`. Any key that names a crudauth logical field, by logical *or* mapped column name, is dropped, so the callback can set the app's own columns but can never override `email`, `hashed_password`, `is_superuser`, `email_verified`, the OAuth linkage, or the primary key. Gating on the mapped name as well as the logical name closes the `column_map` alias hole: an app that maps `is_superuser` to a column named `is_admin` cannot set `is_admin` either. A dropped key is logged so a developer misconfiguration surfaces, but each distinct dropped field warns only once per process (deduped across the constant defaults and the runtime callback) so a standing misconfiguration cannot flood the logs on every signup. Constant `new_user_defaults` are gated once, at construction, so a bad constant is caught at startup rather than per request.

---

## OAuth signup: create-only

On the OAuth path the merge lives inside `OAuthAccountService._create_user`, not in the broader `get_or_create_user`. Provisioning runs only when a genuinely new account is created. The link-existing branch, where a provider is attached to a user that already exists by verified email, does not run it: linking is not creation, and running "set the new-user defaults" against an established row would clobber app state. The merge sits before the username-collision retry, so the contributed columns are present on each insert attempt.

---

## Documentation Updates

**`docs/guides/accounts/registration.md`:**
- New "Setting columns the server controls" section, placed after the client-side `register_extra_fields` material so the two read as a deliberate contrast: what the client may send versus what the server sets. Covers both knobs, the context, the trust boundary, merge order, and gating.

**`docs/api/provisioning.md`** (new):
- API reference page for `NewUserContext`, following the existing `:::` mkdocstrings pattern (intro plus directive). Added to the API nav after Hooks. The new `CRUDAuth` parameters render automatically on the existing `CRUDAuth` page from their docstrings.

**`docs/guides/auth/oauth.md`:**
- One line under "Account linking" pointing readers to the same seam for columns on OAuth-created users, since it runs on that path too.

**`docs/learn/3-modeling-your-user.md`:**
- New "Filling columns the server owns" narrative beat. It reframes the chapter's own nullable/defaulted column examples to set up the required-column problem, then ties the server-versus-client split back to chapter 1's mass-assignment lesson.

---

## Test Plan

### Automated
- [x] `uv run ruff check crudauth tests` — clean
- [x] `uv run mypy crudauth tests --config-file pyproject.toml` — clean (95 files)
- [x] `uv run pytest` — 253 passed

### Provisioning seam (register path)
- [x] Callback sets an app column; persisted on the created row
- [x] Sync and async callbacks both work
- [x] Callback may return a Pydantic model (dumped, then gated)
- [x] No callback configured: model defaults apply, untouched
- [x] `new_user_defaults` constant persists
- [x] Callback merges after defaults (derived overrides constant)
- [x] Callback reads `ctx.db` (first-registered user becomes owner via a live query)
- [x] Context carries `source="register"`, `oauth is None`, and `register_data` minus password

### Gating and trust boundary
- [x] App columns kept, crudauth logical fields dropped + warned
- [x] `column_map` alias dropped (`is_superuser` mapped to `is_admin`, returns `is_admin`)
- [x] Warning fires once per distinct key, then stays quiet; a different key still warns
- [x] `new_user_defaults` gated at construction (a privileged constant dropped + warned at build)
- [x] Mass assignment closed: `is_superuser` / `email_verified` / `email` cannot be set, via the callback (OAuth) and via defaults (register)

### OAuth path
- [x] New OAuth signup runs the callback (`source="oauth"`, `oauth` is the profile)
- [x] `new_user_defaults` applied on OAuth create
- [x] Link-existing does NOT run the callback (proves create-only)
- [x] `suggested_name` returns the OAuth name, falls back to the email local-part

---

## Dependencies

None new.

## Breaking Changes

None. `new_user_fields` and `new_user_defaults` are optional `CRUDAuth` arguments that default to no-ops, so existing configurations are unaffected. `OAuthAccountService.__init__` gained two optional arguments with defaults and stays source-compatible. The only new public symbols are `NewUserContext` and `NewUserFields`, both additive exports.
