### PR TITLE
Pluggable delivery channels: route recovery tokens over any medium

### DIFF
--- a/crudauth/__init__.py
+++ b/crudauth/__init__.py
@@ -18,7 +18,14 @@ from __future__ import annotations
 from importlib.metadata import version
 
 from .core import AuthContext, CookieConfig, Transport
-from .email import EmailConfig, EmailSender
+from .email import (
+    DeliveryChannel,
+    DeliveryIntent,
+    DeliveryKind,
+    EmailChannel,
+    EmailConfig,
+    EmailSender,
+)
 from .exceptions import (
     BadRequestException,
     CSRFException,
@@ -49,6 +56,10 @@ __all__ = [
     "OAuthCredentials",
     "EmailConfig",
     "EmailSender",
+    "DeliveryChannel",
+    "DeliveryIntent",
+    "DeliveryKind",
+    "EmailChannel",
     "AuthHooks",
     "HookContext",
     "NewUserContext",

--- a/crudauth/crud_auth.py
+++ b/crudauth/crud_auth.py
@@ -29,6 +29,7 @@ from .constants import (
     USED_TOKEN_TTL_SECONDS,
 )
 from .core import AuthContext, AuthRuntime, CookieConfig, Transport
+from .email.channel import DeliveryChannel
 from .email.router import build_email_router
 from .email.service import EmailFlowService
 from .exceptions import (
@@ -100,6 +101,7 @@ class CRUDAuth:
         column_map: dict[str, str] | None = None,
         oauth: dict[str, Any] | None = None,
         email: Any = None,
+        channels: list[DeliveryChannel] | None = None,
         hooks: AuthHooks | None = None,
         redirect_base_url: str | None = None,
         algorithm: str = DEFAULT_ALGORITHM,
@@ -129,8 +131,15 @@ class CRUDAuth:
                 column names when they differ (e.g. ``{"hashed_password": "pw_hash"}``).
             oauth: ``{provider_name: OAuthCredentials}`` to enable OAuth login;
                 requires ``redirect_base_url`` and a session transport.
-            email: An [EmailConfig][crudauth.email.config.EmailConfig] to enable verify/reset/change
-                flows; ``None`` disables them.
+            email: An [EmailConfig][crudauth.email.config.EmailConfig] to enable
+                verify/reset/change flows over email (the built-in delivery
+                channel); ``None`` disables email delivery. Either ``email`` or
+                ``channels`` enables the recovery endpoints.
+            channels: Additional [DeliveryChannel][crudauth.email.channel.DeliveryChannel]s
+                to route recovery tokens over (SMS, WhatsApp, push, ...). Fired
+                alongside the email channel if ``email`` is also set, every channel
+                best-effort. With ``channels`` and no ``email``, the recovery
+                endpoints still mount (token lifetimes fall back to the defaults).
             hooks: Lifecycle callbacks ([AuthHooks][crudauth.hooks.AuthHooks]).
             redirect_base_url: Public base URL used to build OAuth redirect URIs
                 and the post-login redirect default.
@@ -226,8 +235,8 @@ class CRUDAuth:
 
         self._email_service: EmailFlowService | None = None
         self._email_token_store: AbstractSessionStorage[Any] | None = None
-        if email is not None:
-            self._build_email(email, algorithm)
+        if email is not None or channels:
+            self._build_email(email, channels, algorithm)
 
         self._oauth_router: APIRouter | None = None
         self._oauth_state_storage: AbstractSessionStorage[Any] | None = None
@@ -357,7 +366,9 @@ class CRUDAuth:
         return self._session_transport.manager
 
     # --- email wiring --------------------------------------------------------
-    def _build_email(self, email: Any, algorithm: str) -> None:
+    def _build_email(
+        self, email: Any, channels: list[DeliveryChannel] | None, algorithm: str
+    ) -> None:
         backend, redis_url = self._backend_config()
         token_store = get_session_storage(
             backend, prefix="used_token:", expiration=USED_TOKEN_TTL_SECONDS, redis_url=redis_url
@@ -367,6 +378,7 @@ class CRUDAuth:
             repo=self.repo,
             secret_key=self.runtime.secret_key,
             config=email,
+            channels=channels,
             hooks=self.hooks,
             algorithm=algorithm,
             token_store=token_store,

--- a/crudauth/email/__init__.py
+++ b/crudauth/email/__init__.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
+from .channel import DeliveryChannel, DeliveryIntent, DeliveryKind, EmailChannel
 from .config import EmailConfig
 from .sender import EmailSender
 from .service import EmailFlowService
 
-__all__ = ["EmailSender", "EmailConfig", "EmailFlowService"]
+__all__ = [
+    "EmailSender",
+    "EmailConfig",
+    "EmailFlowService",
+    "DeliveryChannel",
+    "DeliveryIntent",
+    "DeliveryKind",
+    "EmailChannel",
+]

--- a/crudauth/email/channel.py
+++ b/crudauth/email/channel.py
@@ -1,0 +1,139 @@
+"""Delivery channels: route a recovery token over a medium (email is built in).
+
+crudauth owns the token (mint, one-time-use, redemption); a [DeliveryChannel]
+[crudauth.email.channel.DeliveryChannel] owns the medium and the copy. The
+recovery flows hand each configured channel a [DeliveryIntent]
+[crudauth.email.channel.DeliveryIntent] and fire them all best-effort, so an app
+can route reset/verify over email, SMS, WhatsApp, push, or several at once.
+[EmailChannel][crudauth.email.channel.EmailChannel] is the built-in one.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from .config import EmailConfig
+from .constants import (
+    SUBJECT_CHANGE,
+    SUBJECT_EXISTING_ACCOUNT,
+    SUBJECT_RESET,
+    SUBJECT_VERIFY,
+    EmailKind,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+__all__ = ["DeliveryKind", "DeliveryIntent", "DeliveryChannel", "EmailChannel"]
+
+# The channel-facing name for the message kind. Aliased to EmailKind so there is
+# one source of truth for the values, no translation layer.
+DeliveryKind = EmailKind
+
+
+@dataclass(frozen=True)
+class DeliveryIntent:
+    """A recovery message crudauth needs delivered.
+
+    crudauth owns the token and its lifetime; the channel owns the medium and the
+    copy. Read what you need off ``recipient`` / ``user``; do not assume email.
+
+    Attributes:
+        kind: Which message this is (``verify_email`` / ``reset_password`` /
+            ``change_email`` / ``existing_account``).
+        token: The signed token, or ``None`` for ``existing_account`` (a notice
+            with no action).
+        user: The logical-contract user dict (``repo.to_dict``); empty for the
+            ``existing_account`` notice. Contract fields only, so an app column
+            (``phone``, ``whatsapp_id``, ...) is NOT here - load it off the ``db``
+            handed to [deliver][crudauth.email.channel.DeliveryChannel.deliver].
+        recipient: The resolved recovery destination (the email today; for an
+            email change, the NEW address). A non-email channel typically ignores
+            this and loads its own destination off the user.
+        expires_in: Token lifetime in seconds (``0`` when ``token`` is ``None``).
+    """
+
+    kind: DeliveryKind
+    token: str | None
+    user: dict[str, Any]
+    recipient: str
+    expires_in: int
+
+
+class DeliveryChannel(ABC):
+    """A medium crudauth routes a recovery message over.
+
+    crudauth fires every configured channel best-effort and swallows failures per
+    channel, so raise freely on failure (it never surfaces and never stops the
+    next channel). Reliability (retry/queue) belongs inside a channel.
+
+    Example:
+        ```python
+        class SMSChannel(DeliveryChannel):
+            async def deliver(self, intent: DeliveryIntent, db) -> None:
+                if intent.kind != "reset_password" or intent.token is None or db is None:
+                    return
+                user = await db.get(User, intent.user["id"])   # an app column
+                if user and user.phone:
+                    await sms.enqueue(to=user.phone, token=intent.token)  # hand off
+        ```
+    """
+
+    @abstractmethod
+    async def deliver(self, intent: DeliveryIntent, db: AsyncSession | None) -> None:
+        """Route, render, and send ``intent``.
+
+        Raise on failure (crudauth swallows per channel). Must not assume email;
+        read ``intent.recipient`` / ``intent.user``.
+
+        ``db`` is the request-scoped session for the actionable flows (verify /
+        reset / change), or ``None`` for the ``existing_account`` notice. Use it
+        to load an app column you need (e.g.
+        ``await db.get(User, intent.user["id"])`` for a phone number). It must be
+        used **synchronously** and never committed or captured for deferred work:
+        it is closed when the request ends, so a queued job that kept it would use
+        a dead session. Read what you need, then enqueue the actual delivery.
+        """
+        raise NotImplementedError
+
+
+# kind -> (subject, EmailConfig path attribute, body prefix) for the link kinds.
+_EMAIL_SPECS: dict[str, tuple[str, str, str]] = {
+    "verify_email": (SUBJECT_VERIFY, "verify_path", "Verify your email:"),
+    "reset_password": (SUBJECT_RESET, "reset_path", "Reset your password:"),
+    "change_email": (SUBJECT_CHANGE, "change_path", "Confirm your new email:"),
+}
+
+
+class EmailChannel(DeliveryChannel):
+    """The built-in channel: renders crudauth's recovery copy and calls the
+    [EmailSender][crudauth.email.sender.EmailSender].
+
+    Behaviorally identical to the email delivery crudauth shipped before delivery
+    was pluggable; the subject/body/link building lives here now.
+    """
+
+    def __init__(self, config: EmailConfig):
+        self._config = config
+
+    async def deliver(self, intent: DeliveryIntent, db: AsyncSession | None) -> None:
+        cfg = self._config
+        if intent.kind == "existing_account":
+            await cfg.sender.send(
+                to=intent.recipient,
+                subject=SUBJECT_EXISTING_ACCOUNT,
+                body=(
+                    "Someone tried to register with this email. You already have an "
+                    f"account - sign in or reset your password at {cfg.frontend_url}."
+                ),
+                kind="existing_account",
+            )
+            return
+        subject, path_attr, prefix = _EMAIL_SPECS[intent.kind]
+        assert intent.token is not None
+        link = cfg.link(getattr(cfg, path_attr), intent.token)
+        await cfg.sender.send(
+            to=intent.recipient, subject=subject, body=f"{prefix} {link}", kind=intent.kind
+        )

--- a/crudauth/email/service.py
+++ b/crudauth/email/service.py
@@ -10,7 +10,13 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..constants import DEFAULT_ALGORITHM, SECONDS_PER_HOUR
+from ..constants import (
+    DEFAULT_ALGORITHM,
+    DEFAULT_CHANGE_TTL_HOURS,
+    DEFAULT_RESET_TTL_HOURS,
+    DEFAULT_VERIFY_TTL_HOURS,
+    SECONDS_PER_HOUR,
+)
 from ..exceptions import BadRequestException, DuplicateValueException
 from ..hooks import AuthHooks, HookContext
 from ..ratelimit import RateLimit
@@ -22,6 +28,7 @@ from ..transports.bearer.tokens import (
     verify_signed_token_full,
 )
 from ..utils import canonical_email, get_password_hash, verify_password
+from .channel import DeliveryChannel, DeliveryIntent, EmailChannel
 from .config import EmailConfig
 from .constants import (
     CHANGE,
@@ -29,11 +36,6 @@ from .constants import (
     EXISTING_ACCOUNT_ACTION,
     RESET,
     RESET_ACTION,
-    EmailKind,
-    SUBJECT_CHANGE,
-    SUBJECT_EXISTING_ACCOUNT,
-    SUBJECT_RESET,
-    SUBJECT_VERIFY,
     VERIFY,
     VERIFY_ACTION,
 )
@@ -52,13 +54,18 @@ class _UsedToken(BaseModel):
 
 
 class EmailFlowService:
-    """Mints/verifies signed tokens and drives the email flows.
+    """Mints/verifies signed tokens and drives the recovery flows.
 
-    The package owns token lifecycle; delivery is the app's
-    [EmailSender][crudauth.email.sender.EmailSender]. Trigger endpoints are throttled two ways: a
-    per-IP edge limit (in the router) and a **silent** per-target-email limit
-    here - silent because a 429 on a victim's address would re-introduce the
-    enumeration oracle and hand an attacker a DoS lever against that user.
+    The package owns token lifecycle; *delivery* is pluggable via one or more
+    [DeliveryChannel][crudauth.email.channel.DeliveryChannel]s (email is the
+    built-in one). Trigger endpoints are throttled two ways: a per-IP edge limit
+    (in the router) and a **silent** per-target-email limit here - silent because
+    a 429 on a victim's address would re-introduce the enumeration oracle and
+    hand an attacker a DoS lever against that user.
+
+    Construction is additive: pass ``config=EmailConfig(...)`` (back-compat, which
+    builds an [EmailChannel][crudauth.email.channel.EmailChannel] and seeds the
+    token TTLs) and/or ``channels=[...]`` plus explicit ``*_ttl_hours``.
     """
 
     def __init__(
@@ -66,23 +73,79 @@ class EmailFlowService:
         *,
         repo: UserRepository,
         secret_key: str,
-        config: EmailConfig,
         hooks: AuthHooks,
+        config: EmailConfig | None = None,
+        channels: list[DeliveryChannel] | None = None,
         algorithm: str = DEFAULT_ALGORITHM,
         token_store: AbstractSessionStorage[Any] | None = None,
         session_manager: "SessionManager | None" = None,
         rate_limiter: "RateLimiterBackend | None" = None,
         rate_limits: dict[str, RateLimit] | None = None,
+        verify_ttl_hours: int | None = None,
+        reset_ttl_hours: int | None = None,
+        change_ttl_hours: int | None = None,
     ):
         self.repo = repo
         self.secret_key = secret_key
-        self.config = config
         self.hooks = hooks
         self.algorithm = algorithm
         self.token_store = token_store
         self.session_manager = session_manager
         self.rate_limiter = rate_limiter
         self.rate_limits = rate_limits or {}
+
+        channel_list: list[DeliveryChannel] = []
+        if config is not None:
+            channel_list.append(EmailChannel(config))
+        if channels:
+            channel_list.extend(channels)
+        self._channels = channel_list
+
+        self.verify_ttl_hours = self._resolve_ttl(
+            verify_ttl_hours, config, "verify_ttl_hours", DEFAULT_VERIFY_TTL_HOURS
+        )
+        self.reset_ttl_hours = self._resolve_ttl(
+            reset_ttl_hours, config, "reset_ttl_hours", DEFAULT_RESET_TTL_HOURS
+        )
+        self.change_ttl_hours = self._resolve_ttl(
+            change_ttl_hours, config, "change_ttl_hours", DEFAULT_CHANGE_TTL_HOURS
+        )
+
+    @staticmethod
+    def _resolve_ttl(
+        override: int | None, config: EmailConfig | None, attr: str, default: int
+    ) -> int:
+        """TTL precedence: explicit override, then the EmailConfig's value, then
+        the package default. So a channels-only app still has token lifetimes."""
+        if override is not None:
+            return override
+        if config is not None:
+            return int(getattr(config, attr))
+        return default
+
+    async def _deliver(self, intent: DeliveryIntent, db: AsyncSession | None) -> None:
+        """Fire every configured channel best-effort, forwarding the request ``db``.
+
+        ``db`` is the request session (or ``None`` for the existing-account
+        notice); each channel may read from it synchronously to load an app column.
+
+        Per-channel isolation: the ``try`` is inside the loop, so one channel
+        raising cannot stop the next (a dead WhatsApp integration must not
+        suppress the email that recovers the account). Returns ``None`` regardless
+        and surfaces nothing - the ``request_*`` response is identical whether the
+        user existed or not, and there is deliberately no "at least one succeeded"
+        accounting (observing success would reopen the enumeration oracle).
+        """
+        for channel in self._channels:
+            try:
+                await channel.deliver(intent, db)
+            except Exception:
+                logger.warning(
+                    "crudauth: %s delivery via %s failed",
+                    intent.kind,
+                    type(channel).__name__,
+                    exc_info=True,
+                )
 
     # --- one-time-use guard --------------------------------------------------
     async def _consume(self, token: str, ttl_seconds: int) -> bool:
@@ -115,21 +178,6 @@ class EmailFlowService:
         )
         return not limited
 
-    async def _send_best_effort(self, *, to: str, subject: str, body: str, kind: EmailKind) -> None:
-        """Deliver a trigger email without letting a send failure fail the request.
-
-        These request endpoints only reach the send when the user/address exists,
-        so a propagated send error (blocking adapter + provider down) would 500
-        for existing addresses while absent ones return the uniform success - an
-        existence oracle. Swallow + log instead, preserving non-enumeration.
-        (Senders should enqueue rather than block; this is the safety net when
-        they don't.)
-        """
-        try:
-            await self.config.sender.send(to=to, subject=subject, body=body, kind=kind)
-        except Exception:
-            logger.warning("crudauth: %s email failed to send", kind, exc_info=True)
-
     async def notify_existing_account(self, email: str) -> None:
         """Tell an existing owner someone tried to register with their email.
 
@@ -150,14 +198,11 @@ class EmailFlowService:
         """
         if not await self._email_within_limit(EXISTING_ACCOUNT_ACTION, email):
             return
-        await self.config.sender.send(
-            to=email,
-            subject=SUBJECT_EXISTING_ACCOUNT,
-            body=(
-                "Someone tried to register with this email. You already have an "
-                f"account - sign in or reset your password at {self.config.frontend_url}."
+        await self._deliver(
+            DeliveryIntent(
+                kind="existing_account", token=None, user={}, recipient=email, expires_in=0
             ),
-            kind="existing_account",
+            None,
         )
 
     # --- email verification --------------------------------------------------
@@ -172,14 +217,18 @@ class EmailFlowService:
             self.secret_key,
             self.repo.user_id(user),
             VERIFY,
-            expires_hours=self.config.verify_ttl_hours,
+            expires_hours=self.verify_ttl_hours,
             algorithm=self.algorithm,
         )
-        await self._send_best_effort(
-            to=email,
-            subject=SUBJECT_VERIFY,
-            body=f"Verify your email: {self.config.link(self.config.verify_path, token)}",
-            kind="verify_email",
+        await self._deliver(
+            DeliveryIntent(
+                kind="verify_email",
+                token=token,
+                user=self.repo.to_dict(user),
+                recipient=email,
+                expires_in=self.verify_ttl_hours * SECONDS_PER_HOUR,
+            ),
+            db,
         )
 
     async def confirm_email_verification(self, db: AsyncSession, token: str) -> Any:
@@ -198,7 +247,7 @@ class EmailFlowService:
         sub = verify_signed_token(token, self.secret_key, VERIFY, algorithm=self.algorithm)
         if sub is None:
             raise BadRequestException("Invalid or expired token")
-        if not await self._consume(token, self.config.verify_ttl_hours * SECONDS_PER_HOUR):
+        if not await self._consume(token, self.verify_ttl_hours * SECONDS_PER_HOUR):
             raise BadRequestException("Token already used")
         user = await self.repo.get_by_id(db, sub)
         if user is None:
@@ -222,14 +271,18 @@ class EmailFlowService:
             self.secret_key,
             self.repo.user_id(user),
             RESET,
-            expires_hours=self.config.reset_ttl_hours,
+            expires_hours=self.reset_ttl_hours,
             algorithm=self.algorithm,
         )
-        await self._send_best_effort(
-            to=email,
-            subject=SUBJECT_RESET,
-            body=f"Reset your password: {self.config.link(self.config.reset_path, token)}",
-            kind="reset_password",
+        await self._deliver(
+            DeliveryIntent(
+                kind="reset_password",
+                token=token,
+                user=self.repo.to_dict(user),
+                recipient=email,
+                expires_in=self.reset_ttl_hours * SECONDS_PER_HOUR,
+            ),
+            db,
         )
 
     async def reset_password(self, db: AsyncSession, token: str, new_password: str) -> Any:
@@ -258,7 +311,7 @@ class EmailFlowService:
         sub = verify_signed_token(token, self.secret_key, RESET, algorithm=self.algorithm)
         if sub is None:
             raise BadRequestException("Invalid or expired token")
-        if not await self._consume(token, self.config.reset_ttl_hours * SECONDS_PER_HOUR):
+        if not await self._consume(token, self.reset_ttl_hours * SECONDS_PER_HOUR):
             raise BadRequestException("Token already used")
         user = await self.repo.get_by_id(db, sub)
         if user is None:
@@ -303,15 +356,19 @@ class EmailFlowService:
                 self.secret_key,
                 self.repo.user_id(user),
                 CHANGE,
-                expires_hours=self.config.change_ttl_hours,
+                expires_hours=self.change_ttl_hours,
                 algorithm=self.algorithm,
                 extra_claims={"new_email": new_email_c},
             )
-            await self._send_best_effort(
-                to=new_email_c,
-                subject=SUBJECT_CHANGE,
-                body=f"Confirm your new email: {self.config.link(self.config.change_path, token)}",
-                kind="change_email",
+            await self._deliver(
+                DeliveryIntent(
+                    kind="change_email",
+                    token=token,
+                    user=self.repo.to_dict(user),
+                    recipient=new_email_c,
+                    expires_in=self.change_ttl_hours * SECONDS_PER_HOUR,
+                ),
+                db,
             )
 
     async def confirm_email_change(self, db: AsyncSession, token: str) -> Any:
@@ -341,7 +398,7 @@ class EmailFlowService:
         user = await self.repo.get_by_id(db, payload["sub"])
         if user is None:
             raise BadRequestException("Invalid or expired token")
-        if not await self._consume(token, self.config.change_ttl_hours * SECONDS_PER_HOUR):
+        if not await self._consume(token, self.change_ttl_hours * SECONDS_PER_HOUR):
             raise BadRequestException("Token already used")
         try:
             await self.repo.update(db, user, {"email": new_email, "email_verified": True})

--- a/docs/api/delivery.md
+++ b/docs/api/delivery.md
@@ -1,0 +1,13 @@
+# Delivery channels
+
+Recovery delivery is pluggable: CRUDAuth owns the token (mint, one-time-use, redemption); a
+`DeliveryChannel` owns the medium and the copy. Email is the built-in channel
+([EmailConfig](email.md)); pass `channels=` to [CRUDAuth](crud-auth.md) to add SMS, WhatsApp,
+push, fired alongside it best-effort. See the
+[email flows guide](../guides/accounts/email.md#delivery-channels) for usage.
+
+::: crudauth.email.channel.DeliveryChannel
+
+::: crudauth.email.channel.DeliveryIntent
+
+::: crudauth.email.channel.EmailChannel

--- a/docs/guides/accounts/email.md
+++ b/docs/guides/accounts/email.md
@@ -77,6 +77,52 @@ The `-request` endpoints always return `200`, whether or not the address exists,
 don't leak which accounts are registered. Tokens are single-use and time-limited
 (`verify_ttl_hours`, `reset_ttl_hours`, `change_ttl_hours` on `EmailConfig`).
 
+## Delivery channels
+
+Email is the built-in delivery channel, but the token isn't email-specific. CRUDAuth owns the
+token (mint, one-time-use, redemption); a `DeliveryChannel` owns the medium and the copy. Pass
+`channels=` to route the same reset/verify token over SMS, WhatsApp, push, or several at once:
+
+```python
+from crudauth import CRUDAuth, DeliveryChannel, DeliveryIntent, EmailConfig
+
+class SMSChannel(DeliveryChannel):
+    async def deliver(self, intent: DeliveryIntent, db) -> None:
+        if intent.kind != "reset_password" or intent.token is None or db is None:
+            return
+        user = await db.get(User, intent.user["id"])   # load an app column synchronously
+        if user and user.phone:
+            link = f"https://app.example.com/reset-password?token={intent.token}"
+            await sms.enqueue(to=user.phone, body=f"Reset your password: {link}")  # hand off
+
+auth = CRUDAuth(
+    session=get_session, user_model=User, SECRET_KEY="change-me",
+    email=EmailConfig(sender=MySender(), frontend_url="https://app.example.com"),
+    channels=[SMSChannel()],
+)
+```
+
+Every configured channel fires for each flow, **best-effort and independent**: a channel that
+raises is logged and skipped, and never stops another channel or changes the endpoint's
+uniform `200` (so a dead integration can't leak which accounts exist or block the channel that
+actually recovers the account). Reliability (retry, queueing) lives inside a channel.
+
+`email=EmailConfig(...)` is just the built-in `EmailChannel`. With `channels=` and no
+`EmailConfig`, the recovery endpoints still mount, and token lifetimes fall back to the
+defaults (or pass `verify_ttl_hours` / `reset_ttl_hours` / `change_ttl_hours` to `CRUDAuth`).
+
+`deliver(intent, db)` receives the message descriptor plus the request session. Two things to
+know:
+
+- `intent.recipient` is the **email address** (the recovery lookup is still keyed on email;
+  per-field recovery like phone-as-identifier is a separate step). A non-email channel ignores
+  it and loads its own destination, as the SMS example does.
+- `intent.user` holds only CRUDAuth's logical fields, so an app column like `phone` isn't in
+  it. Read it off `db` with `intent.user["id"]` (the session is present for verify/reset/change,
+  `None` for the existing-account notice). Use `db` **synchronously** and never commit or
+  capture it: it closes when the request ends, so read what you need, then enqueue the send
+  (as above) rather than blocking on it.
+
 ## Hooks
 
 `on_after_email_verified`, `on_after_password_reset`, and `on_after_email_changed` fire after

--- a/tests/email/test_channels.py
+++ b/tests/email/test_channels.py
@@ -1,0 +1,266 @@
+"""Pluggable delivery channels: multi-channel best-effort, per-channel isolation,
+the non-enumeration contract held across N channels, and channels-only apps."""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import FastAPI
+
+from crudauth import (
+    AuthHooks,
+    CookieConfig,
+    CRUDAuth,
+    DeliveryChannel,
+    DeliveryIntent,
+    EmailConfig,
+    EmailSender,
+    SessionTransport,
+)
+from crudauth.constants import DEFAULT_RESET_TTL_HOURS, SECONDS_PER_HOUR
+from crudauth.email.service import EmailFlowService
+from crudauth.repository import UserRepository
+from crudauth.utils import get_password_hash
+
+SECRET = "test-secret-key-0123456789-0123456789"
+
+
+class RecordingChannel(DeliveryChannel):
+    def __init__(self) -> None:
+        self.intents: list[DeliveryIntent] = []
+
+    async def deliver(self, intent: DeliveryIntent, db) -> None:
+        self.intents.append(intent)
+
+
+class BoomChannel(DeliveryChannel):
+    async def deliver(self, intent: DeliveryIntent, db) -> None:
+        raise RuntimeError("channel down")
+
+
+class CapturingSender(EmailSender):
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send(self, *, to, subject, body, kind) -> None:
+        self.sent.append({"to": to, "subject": subject, "body": body, "kind": kind})
+
+
+async def _make_user(repo, sessionmaker, email="real@x.com") -> None:
+    async with sessionmaker() as db:
+        await repo.create(
+            db,
+            {
+                "email": email,
+                "username": email.split("@")[0],
+                "hashed_password": get_password_hash("pw"),
+            },
+        )
+
+
+def _service(UserModel, **kwargs) -> EmailFlowService:
+    return EmailFlowService(
+        repo=UserRepository(UserModel), secret_key=SECRET, hooks=AuthHooks(), **kwargs
+    )
+
+
+# --- security-critical: the non-enumeration contract across N channels ----
+
+
+async def test_raising_channel_does_not_surface(sessionmaker, UserModel) -> None:
+    # An existing user with a failing channel must not 500 (would be an oracle);
+    # absent user returns early. Both complete without raising.
+    repo = UserRepository(UserModel)
+    await _make_user(repo, sessionmaker)
+    svc = _service(UserModel, channels=[BoomChannel()])
+    async with sessionmaker() as db:
+        await svc.request_password_reset(db, "real@x.com")  # channel raises internally
+        await svc.request_password_reset(db, "ghost@x.com")  # absent: early return
+
+
+async def test_one_channel_failure_does_not_stop_another(sessionmaker, UserModel) -> None:
+    repo = UserRepository(UserModel)
+    await _make_user(repo, sessionmaker)
+    rec = RecordingChannel()
+    svc = _service(UserModel, channels=[BoomChannel(), rec])
+    async with sessionmaker() as db:
+        await svc.request_password_reset(db, "real@x.com")
+    assert len(rec.intents) == 1  # the second channel still fired
+    assert rec.intents[0].kind == "reset_password"
+    assert rec.intents[0].token is not None
+
+
+async def test_absent_user_fires_no_channel(sessionmaker, UserModel) -> None:
+    rec = RecordingChannel()
+    svc = _service(UserModel, channels=[rec])
+    async with sessionmaker() as db:
+        await svc.request_password_reset(db, "ghost@x.com")
+    assert rec.intents == []  # early-return preserved
+
+
+# --- multi-channel + channels-only ----------------------------------------
+
+
+async def test_email_and_extra_channel_both_receive(sessionmaker, UserModel) -> None:
+    repo = UserRepository(UserModel)
+    await _make_user(repo, sessionmaker)
+    sender = CapturingSender()
+    rec = RecordingChannel()
+    svc = _service(
+        UserModel,
+        config=EmailConfig(sender=sender, frontend_url="https://app"),
+        channels=[rec],
+    )
+    async with sessionmaker() as db:
+        await svc.request_password_reset(db, "real@x.com")
+    assert [m["kind"] for m in sender.sent] == ["reset_password"]  # email channel
+    assert [i.kind for i in rec.intents] == ["reset_password"]  # extra channel
+
+
+async def test_channels_only_endpoints_mount_and_fire(get_session, UserModel, sessionmaker) -> None:
+    # No EmailConfig at all: recovery endpoints still exist and the channel fires,
+    # with token lifetimes falling back to the package defaults.
+    rec = RecordingChannel()
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=UserModel,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        channels=[rec],
+    )
+    await _make_user(UserRepository(UserModel), sessionmaker, email="reset@x.com")
+    app = FastAPI()
+    app.include_router(auth.router)
+    await auth.initialize()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        r = await c.post("/password/reset-request", json={"email": "reset@x.com"})
+        assert r.status_code == 200
+    await auth.shutdown()
+    assert len(rec.intents) == 1
+    assert rec.intents[0].kind == "reset_password"
+    assert rec.intents[0].expires_in == DEFAULT_RESET_TTL_HOURS * SECONDS_PER_HOUR
+
+
+async def test_channel_can_load_app_column_via_db(sessionmaker, UserModel) -> None:
+    # The actionable flows carry a live session, so a channel can re-load an app
+    # column not in the contract dict (here full_name; for a real SMS channel, phone).
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        await repo.create(
+            db,
+            {
+                "email": "n@x.com",
+                "username": "n",
+                "hashed_password": get_password_hash("pw"),
+                "full_name": "Ned",
+            },
+        )
+
+    loaded: list[str] = []
+
+    class NameChannel(DeliveryChannel):
+        async def deliver(self, intent: DeliveryIntent, db) -> None:
+            assert db is not None
+            row = await db.get(UserModel, intent.user["id"])
+            assert row is not None
+            loaded.append(row.full_name)
+
+    svc = _service(UserModel, channels=[NameChannel()])
+    async with sessionmaker() as db:
+        await svc.request_password_reset(db, "n@x.com")
+    assert loaded == ["Ned"]
+
+
+async def test_config_seeds_flow_ttls(sessionmaker, UserModel) -> None:
+    # A NON-default EmailConfig TTL must flow through to the intent (the back-compat
+    # seeding path), distinct from the package default - so this would fail if
+    # _resolve_ttl ignored config and fell through to the default.
+    repo = UserRepository(UserModel)
+    await _make_user(repo, sessionmaker, email="t@x.com")
+    rec = RecordingChannel()
+    svc = _service(
+        UserModel,
+        config=EmailConfig(sender=CapturingSender(), frontend_url="https://app", reset_ttl_hours=2),
+        channels=[rec],
+    )
+    async with sessionmaker() as db:
+        await svc.request_password_reset(db, "t@x.com")
+    assert rec.intents[0].expires_in == 2 * SECONDS_PER_HOUR
+    assert 2 != DEFAULT_RESET_TTL_HOURS  # guards the test itself: 2 is non-default
+
+
+async def test_existing_account_notice_passes_no_db(UserModel) -> None:
+    # notify_existing_account has no session, so the notice intent is delivered
+    # with db=None (the actionable flows get a real session; this one doesn't).
+    class DbChannel(DeliveryChannel):
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, object]] = []
+
+        async def deliver(self, intent: DeliveryIntent, db) -> None:
+            self.calls.append((intent.kind, db))
+
+    ch = DbChannel()
+    svc = _service(UserModel, channels=[ch])
+    await svc.notify_existing_account("v@x.com")
+    assert ch.calls == [("existing_account", None)]
+
+
+async def test_facade_fires_email_and_channels_together(
+    get_session, UserModel, sessionmaker
+) -> None:
+    # Through the mounted endpoint with BOTH email and an extra channel configured,
+    # both fire (proves the facade gate + _build_email pass both into the service).
+    sender = CapturingSender()
+    rec = RecordingChannel()
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=UserModel,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        email=EmailConfig(sender=sender, frontend_url="https://app"),
+        channels=[rec],
+    )
+    await _make_user(UserRepository(UserModel), sessionmaker, email="both@x.com")
+    app = FastAPI()
+    app.include_router(auth.router)
+    await auth.initialize()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        r = await c.post("/password/reset-request", json={"email": "both@x.com"})
+        assert r.status_code == 200
+    await auth.shutdown()
+    assert [m["kind"] for m in sender.sent] == ["reset_password"]  # email channel
+    assert [i.kind for i in rec.intents] == ["reset_password"]  # extra channel
+
+
+# --- intent shape per kind -------------------------------------------------
+
+
+async def test_intent_shapes_per_kind(sessionmaker, UserModel) -> None:
+    repo = UserRepository(UserModel)
+    await _make_user(repo, sessionmaker, email="u@x.com")
+    rec = RecordingChannel()
+    svc = _service(
+        UserModel, channels=[rec], verify_ttl_hours=24, reset_ttl_hours=1, change_ttl_hours=12
+    )
+    async with sessionmaker() as db:
+        user = await repo.get_by_email(db, "u@x.com")
+        await svc.request_email_verification(db, "u@x.com")
+        await svc.request_password_reset(db, "u@x.com")
+        await svc.request_email_change(db, user, "new@x.com", "pw")
+        await svc.notify_existing_account("u@x.com")
+
+    by_kind = {i.kind: i for i in rec.intents}
+
+    assert by_kind["verify_email"].token is not None
+    assert by_kind["verify_email"].expires_in == 24 * SECONDS_PER_HOUR
+    assert by_kind["reset_password"].token is not None
+    assert by_kind["reset_password"].expires_in == 1 * SECONDS_PER_HOUR
+    # change routes to the NEW address, not the current one
+    assert by_kind["change_email"].recipient == "new@x.com"
+    assert by_kind["change_email"].expires_in == 12 * SECONDS_PER_HOUR
+    # the existing-account notice carries no token and no expiry
+    assert by_kind["existing_account"].token is None
+    assert by_kind["existing_account"].expires_in == 0

--- a/zensical.toml
+++ b/zensical.toml
@@ -125,6 +125,7 @@ edit_uri = "edit/main/docs/"
     { "Transports" = "api/transports.md" },
     { "OAuth" = "api/oauth.md" },
     { "Email" = "api/email.md" },
+    { "Delivery channels" = "api/delivery.md" },
     { "Hooks" = "api/hooks.md" },
     { "Provisioning" = "api/provisioning.md" },
     { "Sudo" = "api/sudo.md" },


### PR DESCRIPTION
# Pluggable delivery channels: route recovery tokens over any medium

The recovery flows (verify, reset, change) welded two jobs together: owning the token and delivering an email. This branch separates them. crudauth keeps owning the token (mint, one-time-use, redemption); delivery becomes a pluggable `DeliveryChannel` port, so an app can route the reset/verify token over email, SMS, WhatsApp, push, or several at once, fired best-effort. Email becomes one built-in channel, so existing `email=EmailConfig(...)` apps are unchanged. It is fully additive: the existing email-flow test suite passes untouched.

---

## Pluggable delivery channels

Before this branch, `EmailFlowService` both minted/verified the signed token and built the subject/body/link and called `EmailSender.send`. Delivery was hardcoded to email; there was no way to also notify over another medium, and an app that wanted SMS-only recovery had nowhere to put it.

The line is now drawn at the token. A flow produces a `DeliveryIntent` (the `kind`, the signed `token`, the `recipient`, `expires_in`, and the logical-contract `user` dict) and hands it to one or more `DeliveryChannel`s. The channel owns the medium and the copy; crudauth owns the token and the kind. `EmailChannel` is the built-in channel: it absorbs the link/subject/body building that used to live in the service, so its output is byte-identical to what shipped before. New channels implement one method:

```python
class DeliveryChannel(ABC):
    async def deliver(self, intent: DeliveryIntent, db: AsyncSession | None) -> None: ...
```

`email=EmailConfig(...)` now internally constructs an `EmailChannel`; `channels=[...]` appends more. Both may be set (email plus extra channels, all fired). The router gate changed from "email configured" to "email or channels configured," so an app with only `channels=[WhatsAppChannel(...)]` and no `EmailConfig` still gets the recovery endpoints.

**Why a port and not a config flag:** delivery media differ in copy, destination resolution, and reliability handling. A port lets each live in its own adapter (the assumption-free-port convention the transports already follow) instead of accreting `if sms:` branches in the flow.

---

## The non-enumeration contract across N channels

This is the security heart. The old code wrapped the email send in `_send_best_effort` because a raised send is an enumeration oracle: an existing recipient would 500 while an absent one returned the uniform success, and the difference leaks existence. With N channels the contract becomes per-channel swallow, fire all, short-circuit nothing, surface nothing:

```python
for channel in self._channels:
    try:
        await channel.deliver(intent, db)
    except Exception:
        logger.warning("crudauth: %s delivery via %s failed", intent.kind, type(channel).__name__)
```

Three properties hold: the `try` is inside the loop (one channel raising cannot stop the next, so a dead WhatsApp integration cannot suppress the email that actually recovers the account); `_deliver` returns `None` regardless and the `request_*` response is identical whether or not the user existed; and there is deliberately no "at least one succeeded" accounting, because observing success would force surfacing a total-failure case and reopen the oracle. The pre-send existence checks (`get_by_email` early-return) and the silent per-target-email throttle are untouched: the swallow handles delivery failure, the early-return handles non-existence, and both are still needed.

---

## Token TTLs moved to the flow level

Token lifetimes used to live on `EmailConfig`. That is wrong once email is just one channel: a WhatsApp-only app still needs `reset_ttl`, but would have no `EmailConfig` to put it on. TTLs are crudauth's concern (token lifetime), not a channel's, so they moved up to `EmailFlowService` with the precedence explicit override, then the `EmailConfig` value (back-compat seeding), then the package default. A channels-only app therefore still has token lifetimes (the defaults, or explicit `*_ttl_hours`).

The constructor is **additive**: it still accepts `config=EmailConfig(...)` (which builds the `EmailChannel` and seeds the TTLs) and now also accepts `channels=` and `verify_ttl_hours` / `reset_ttl_hours` / `change_ttl_hours`. The redemption half (`confirm_*` / `reset_password`) is otherwise byte-for-byte identical: its only diff is the three `_consume` TTL sources moving from `self.config.*_ttl_hours` to `self.*_ttl_hours`, a value-identical rename that does not touch token verification, version bumping, or session eviction.

---

## Where `db` belongs: a `deliver()` parameter, not on the intent

A channel often needs an app column the contract dict doesn't carry (a `phone` for SMS), so it needs the request session to load it. The session is passed as the second argument to `deliver(intent, db)`, not as a field on `DeliveryIntent`. That matches crudauth's existing precedent: hooks receive `db` as a separate kwarg and keep it out of the data object (`HookContext` deliberately holds no session). It also keeps `DeliveryIntent` a pure, immutable value rather than a frozen record with a live mutable session glued on, which removes the temptation to stash the intent (and a closed session) for deferred work.

The contract, documented on the port: use `db` synchronously to gather what you need, then enqueue the actual send; never commit it or capture it for a background job, because it closes when the request ends. This is the same rule the sibling project (sapari) enforces structurally, where a live session never crosses into delivery and workers reload with their own session. `db` is the request session for the actionable flows (verify/reset/change) and `None` for the existing-account notice (whose service method has no session).

---

## Documentation Updates

**`docs/guides/accounts/email.md`:**
- New "Delivery channels" section: a worked `SMSChannel` that loads `phone` off the `deliver` `db` and enqueues the send, the best-effort/per-channel-isolation guarantee, the channels-only plus TTL-fallback note, and the two honest caveats (`recipient` is still the email until the separate `recovery_field` step; `user` is contract-only so app columns come off `db`).

**`docs/api/delivery.md`** (new):
- API page for `DeliveryChannel`, `DeliveryIntent`, and `EmailChannel` via the `:::` mkdocstrings pattern; added to the API nav after Email. The new `CRUDAuth(channels=...)` parameter renders on the existing `CRUDAuth` page from its docstring.

---

## Test Plan

### Automated
- [x] `uv run ruff check crudauth tests` — clean
- [x] `uv run mypy crudauth tests --config-file pyproject.toml` — clean (97 files)
- [x] `uv run pytest` — 263 passed

### Channel delivery and isolation
- [x] A raising channel does not surface (existing user does not 500; absent user returns early) and the failure is swallowed
- [x] One channel failing does not stop another (first raises, second still receives the intent)
- [x] Absent user fires no channel (early-return preserved)
- [x] Email plus an extra channel both receive the intent (service level)
- [x] The facade fires email and an extra channel together through the mounted `/password/reset-request`

### Channels-only and TTLs
- [x] Channels-only (no `EmailConfig`) mounts the recovery endpoints and fires, token lifetime falling back to the default
- [x] A non-default `EmailConfig(reset_ttl_hours=2)` seeds the flow TTL (`expires_in == 2 * SECONDS_PER_HOUR`), distinguishing config-seeding from the default fallback

### DB access from a channel
- [x] A channel loads an app column via the `deliver` `db` on an actionable flow
- [x] The existing-account notice is delivered with `db=None`

### Intent shape per kind
- [x] reset/verify carry a token and the correct `expires_in`; `existing_account` carries `token=None`/`expires_in=0`; change routes to the new address

### Back-compat (the relocation did not change behavior)
- [x] `tests/email/test_flows.py` and `tests/email/test_ratelimit.py` pass unchanged (email behavior byte-identical; redemption logic untouched)

---

## Dependencies

None new.

## Breaking Changes

None. The `EmailFlowService` constructor is additive: `config` became optional (defaulting to `None`), and `channels` plus `verify_ttl_hours`/`reset_ttl_hours`/`change_ttl_hours` were added; all arguments are keyword-only, so existing `config=...` callers are unaffected. The private `_send_best_effort` helper was removed (its role is now `_deliver`); it was never public. New public exports: `DeliveryChannel`, `DeliveryIntent`, `DeliveryKind`, `EmailChannel`.
