### PR TITLE
Identity contract: model-driven login and recovery, email-optional accounts

### DIFF
--- a/crudauth/__init__.py
+++ b/crudauth/__init__.py
@@ -39,6 +39,8 @@ from .exceptions import (
 )
 from .crud_auth import CRUDAuth
 from .hooks import AuthHooks, HookContext
+from .identity import IdentityConfig
+from .models.mixin import AuthUserMixin, make_auth_identity
 from .oauth import OAuthCredentials
 from .principal import Principal
 from .provisioning import NewUserContext, NewUserFields
@@ -62,6 +64,9 @@ __all__ = [
     "EmailChannel",
     "AuthHooks",
     "HookContext",
+    "IdentityConfig",
+    "AuthUserMixin",
+    "make_auth_identity",
     "NewUserContext",
     "NewUserFields",
     "Transport",

--- a/crudauth/crud_auth.py
+++ b/crudauth/crud_auth.py
@@ -39,6 +39,7 @@ from .exceptions import (
     UnauthorizedException,
 )
 from .hooks import AuthHooks
+from .identity import IdentityConfig
 from .oauth import OAuthAccountService, OAuthProviderFactory
 from .oauth.router import build_oauth_router
 from .principal import Principal
@@ -99,6 +100,7 @@ class CRUDAuth:
         SECRET_KEY: str,
         transports: Sequence[Transport] | None = None,
         column_map: dict[str, str] | None = None,
+        identity: IdentityConfig | None = None,
         oauth: dict[str, Any] | None = None,
         email: Any = None,
         channels: list[DeliveryChannel] | None = None,
@@ -201,7 +203,11 @@ class CRUDAuth:
         if not SECRET_KEY:
             raise ValueError("SECRET_KEY is required")
         self.session = session
-        self.repo = UserRepository(user_model, column_map, register_extra_fields)
+        self.identity = identity or IdentityConfig()
+        self.repo = UserRepository(
+            user_model, column_map, register_extra_fields, login_fields=self.identity.login
+        )
+        self._validate_identity(oauth=oauth, email=email)
         self.new_user_fields = new_user_fields
         self._new_user_defaults = self.repo.filter_provisioning_data(new_user_defaults or {})
         self.hooks = hooks or AuthHooks()
@@ -235,7 +241,7 @@ class CRUDAuth:
 
         self._email_service: EmailFlowService | None = None
         self._email_token_store: AbstractSessionStorage[Any] | None = None
-        if email is not None or channels:
+        if self.identity.recovery is not None and (email is not None or channels):
             self._build_email(email, channels, algorithm)
 
         self._oauth_router: APIRouter | None = None
@@ -275,6 +281,34 @@ class CRUDAuth:
             on_login_success=st.on_login_success if st else "clear_all",
             fail_open=False,
         )
+
+    def _validate_identity(self, *, oauth: dict[str, Any] | None, email: Any) -> None:
+        """Check the identity contract against the model, fail-closed at construction.
+
+        The model owns the shape; this asserts the config agrees with it, so a
+        login field that isn't a unique column, a non-unique recovery field, OAuth
+        without an email login, or an email flow on a model with no email column
+        all raise here rather than splitting into a silent second source of truth.
+        """
+        for login_field in self.identity.login:
+            if not self.repo.is_unique_column(login_field):
+                raise ValueError(
+                    f"identity.login field '{login_field}' is not a unique column on the user "
+                    "model; every login field must be a single-field unique column."
+                )
+        recovery = self.identity.recovery
+        if recovery is not None and not self.repo.is_unique_column(recovery):
+            raise ValueError(
+                f"identity.recovery field '{recovery}' is not a unique column on the user "
+                "model; the recovery field must be a single-field unique column."
+            )
+        if oauth and "email" not in self.identity.login:
+            raise ValueError(
+                "OAuth requires 'email' in identity.login - OAuth links and creates accounts "
+                "by email, so an email-less contract cannot enable OAuth."
+            )
+        if email is not None and not self.repo.has("email"):
+            raise ValueError("email=EmailConfig(...) requires an 'email' column on the user model.")
 
     def _warn_on_register_extra_fields(self, extra: set[str] | None) -> None:
         """Warn when ``register_extra_fields`` tries to opt in a privileged field.
@@ -518,6 +552,11 @@ class CRUDAuth:
                 ...
             ```
         """
+        if verified and not self.repo.has("email"):
+            raise ValueError(
+                "current_user(verified=True) gates on email_verified, which requires an "
+                "email column on the user model. (PR-1 placeholder; recovery_verified is PR 2.)"
+            )
         selected = self._select_transports(transport)
         required_scopes = list(scopes or [])
 

--- a/crudauth/identity.py
+++ b/crudauth/identity.py
@@ -1,0 +1,40 @@
+"""The identity contract: the login/recovery intent the model's columns can't carry.
+
+The model owns the *shape* (which columns exist, nullable, unique);
+[IdentityConfig][crudauth.identity.IdentityConfig] owns the *intent* a schema
+can't express, and [CRUDAuth][crudauth.crud_auth.CRUDAuth] validates the two
+against each other at construction, so a config that contradicts the model fails
+loudly at startup instead of splitting into a silent second source of truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = ["IdentityConfig"]
+
+
+@dataclass(frozen=True)
+class IdentityConfig:
+    """How an account's identity behaves, validated against the model at construction.
+
+    Attributes:
+        login: Logical fields a login identifier is matched against, in order;
+            first match wins. Each must be a unique column on the model (asserted
+            at construction, which is what makes first-match-wins safe).
+        recovery: The single field verify/reset/change is delivered against, or
+            ``None`` to disable recovery (the recovery endpoints aren't mounted).
+            Must be a unique column when set.
+
+    Example:
+        ```python
+        # username login, phone recovery
+        CRUDAuth(..., identity=IdentityConfig(login=["username"], recovery="phone"))
+
+        # anonymous: username login, no recovery at all
+        CRUDAuth(..., identity=IdentityConfig(login=["username"], recovery=None))
+        ```
+    """
+
+    login: list[str] = field(default_factory=lambda: ["email", "username"])
+    recovery: str | None = "email"

--- a/crudauth/models/mixin.py
+++ b/crudauth/models/mixin.py
@@ -1,63 +1,144 @@
-"""The [AuthUserMixin][crudauth.models.mixin.AuthUserMixin] - inherit it and get every column crudauth needs.
+"""The auth user-model columns, emitted by [make_auth_identity]
+[crudauth.models.mixin.make_auth_identity].
 
-Your own columns coexist freely. If you have an existing table with different
-column names, don't rename your schema - map the contract via
-``column_map=`` on [CRUDAuth][crudauth.crud_auth.CRUDAuth] instead.
+Inherit [AuthUserMixin][crudauth.models.mixin.AuthUserMixin] (the default output)
+and get every column crudauth needs. Your own columns coexist freely. For a
+different account shape (username-only login, phone recovery, no recovery at all)
+call the factory yourself. If you have an existing table with different column
+names, don't rename your schema - map the contract via ``column_map=`` on
+[CRUDAuth][crudauth.crud_auth.CRUDAuth] instead.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any, Iterable
 
 from sqlalchemy import DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column
 
-__all__ = ["AuthUserMixin"]
+__all__ = ["AuthUserMixin", "make_auth_identity"]
 
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
-class AuthUserMixin:
-    """Declarative mixin supplying the full set of columns crudauth relies on.
+def make_auth_identity(
+    *,
+    identifiers: Iterable[str] = ("email", "username"),
+    recovery: str | None = "email",
+    oauth: bool = True,
+) -> type[Any]:
+    """Build a declarative mixin carrying crudauth's user columns for one account shape.
 
-    Note:
-        ``token_version`` is a monotonic credential epoch: bearer tokens embed it
-        as the ``ver`` claim and a password reset bumps it, so a reset rejects
-        every outstanding bearer token. See
-        [BearerTransport][crudauth.transports.bearer.transport.BearerTransport].
+    The model is the source of truth for shape: this emits the columns, and
+    [CRUDAuth][crudauth.crud_auth.CRUDAuth] reads them back at construction, so the
+    two can't disagree. ``username``, ``hashed_password``, the status flags,
+    ``token_version``, and the timestamps are always emitted; ``email`` and the
+    oauth-linkage columns are conditional.
+
+    Args:
+        identifiers: Logical fields a user may log in with. Each becomes a
+            ``NOT NULL`` unique column. ``email`` here makes the email column
+            required.
+        recovery: The single field recovery (verify/reset/change) is delivered
+            against, or ``None`` for an account shape with no recovery. ``"email"``
+            (and not an identifier) makes the email column nullable but unique.
+        oauth: Emit the oauth-linkage columns (``oauth_provider`` / ``google_id`` /
+            ``github_id`` / timestamps). Required for OAuth login.
+
+    Returns:
+        A declarative mixin class. Inherit it on your model alongside ``Base``.
 
     Example:
         ```python
+        # the default - email + username login, email recovery (today's shape)
         class User(Base, AuthUserMixin):
             __tablename__ = "users"
-            full_name: Mapped[str | None] = mapped_column(default=None)
+
+        # username-only login, phone recovery
+        Identity = make_auth_identity(identifiers=["username"], recovery="phone")
+        class User(Base, Identity):
+            __tablename__ = "users"
+            phone: Mapped[str | None] = mapped_column(unique=True, default=None)
         ```
     """
+    ns: dict[str, Any] = {}
+    ann: dict[str, Any] = {}
 
-    # --- core identity -------------------------------------------------------
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
-    username: Mapped[str] = mapped_column(String(64), unique=True, index=True)
-    hashed_password: Mapped[str] = mapped_column(String(255))
+    def add(name: str, annotation: Any, column: Any) -> None:
+        ann[name] = annotation
+        ns[name] = column
 
-    # --- status flags --------------------------------------------------------
-    is_active: Mapped[bool] = mapped_column(default=True)
-    is_superuser: Mapped[bool] = mapped_column(default=False)
-    email_verified: Mapped[bool] = mapped_column(default=False)
+    identifier_set = set(identifiers)
+    email_is_identifier = "email" in identifier_set
+    email_is_recovery = recovery == "email"
 
-    token_version: Mapped[int] = mapped_column(default=0)
+    add("id", Mapped[int], mapped_column(primary_key=True, autoincrement=True))
+    if email_is_identifier:
+        add("email", Mapped[str], mapped_column(String(320), unique=True, index=True))
+    elif email_is_recovery:
+        add(
+            "email",
+            Mapped[str | None],
+            mapped_column(String(320), unique=True, index=True, default=None),
+        )
+    add("username", Mapped[str], mapped_column(String(64), unique=True, index=True))
+    add("hashed_password", Mapped[str], mapped_column(String(255)))
 
-    # --- oauth linkage -------------------------------------------------------
-    oauth_provider: Mapped[str | None] = mapped_column(String(32), default=None)
-    google_id: Mapped[str | None] = mapped_column(String(64), unique=True, index=True, default=None)
-    github_id: Mapped[str | None] = mapped_column(String(64), unique=True, index=True, default=None)
-    oauth_created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
-    oauth_updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    add("is_active", Mapped[bool], mapped_column(default=True))
+    add("is_superuser", Mapped[bool], mapped_column(default=False))
+    add("email_verified", Mapped[bool], mapped_column(default=False))
+    add("token_version", Mapped[int], mapped_column(default=0))
 
-    # --- timestamps ----------------------------------------------------------
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
-    updated_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), default=None, onupdate=_utcnow
+    if oauth:
+        add("oauth_provider", Mapped[str | None], mapped_column(String(32), default=None))
+        add(
+            "google_id",
+            Mapped[str | None],
+            mapped_column(String(64), unique=True, index=True, default=None),
+        )
+        add(
+            "github_id",
+            Mapped[str | None],
+            mapped_column(String(64), unique=True, index=True, default=None),
+        )
+        add(
+            "oauth_created_at",
+            Mapped[datetime | None],
+            mapped_column(DateTime(timezone=True), default=None),
+        )
+        add(
+            "oauth_updated_at",
+            Mapped[datetime | None],
+            mapped_column(DateTime(timezone=True), default=None),
+        )
+
+    add("created_at", Mapped[datetime], mapped_column(DateTime(timezone=True), default=_utcnow))
+    add(
+        "updated_at",
+        Mapped[datetime | None],
+        mapped_column(DateTime(timezone=True), default=None, onupdate=_utcnow),
     )
+
+    ns["__annotations__"] = ann
+    return type("AuthUserMixin", (), ns)
+
+
+AuthUserMixin = make_auth_identity()
+"""Default identity columns: email + username login, email recovery, oauth enabled.
+
+Inherit this for the standard account shape (it is exactly
+``make_auth_identity()``):
+
+```python
+class User(Base, AuthUserMixin):
+    __tablename__ = "users"
+    full_name: Mapped[str | None] = mapped_column(default=None)
+```
+
+``token_version`` is a monotonic credential epoch: bearer tokens embed it as the
+``ver`` claim and a password reset bumps it, so a reset rejects every outstanding
+bearer token.
+"""

--- a/crudauth/provisioning.py
+++ b/crudauth/provisioning.py
@@ -63,11 +63,13 @@ class NewUserContext:
 
     @property
     def suggested_name(self) -> str:
-        """A display name to default to: the OAuth name if present, else the
-        email local-part."""
+        """A display name to default to: the OAuth name, else the email local-part,
+        else the username - so it stays useful across email and email-less shapes."""
         if self.oauth is not None and self.oauth.name:
             return self.oauth.name
-        return self.email.split("@")[0]
+        if self.email:
+            return self.email.split("@")[0]
+        return self.username
 
 
 NewUserFields = Callable[

--- a/crudauth/register/route.py
+++ b/crudauth/register/route.py
@@ -87,12 +87,12 @@ def build_register_route(auth: Any, schema: type[BaseModel] | None) -> APIRouter
         """
         ip = get_client_ip(request, auth.runtime.trusted_proxy_hops)
         email_on = auth._email_service is not None
+        login_fields = auth.identity.login
         data = cast(BaseModel, body).model_dump()
         password = data.pop("password")
         submitted = dict(data)
         data = auth.repo.filter_registration_data(data)
-        email = data.pop("email")
-        username = data.pop("username")
+        login_values = {f: data.pop(f) for f in login_fields}
 
         async def _send_best_effort(coro: Awaitable[Any]) -> None:
             """Dispatch a registration email without letting a send failure fail
@@ -117,23 +117,33 @@ def build_register_route(auth: Any, schema: type[BaseModel] | None) -> APIRouter
             race-recovery so a concurrent duplicate yields the same clean result
             (202 when email is configured, else a duplicate error) instead of a
             500, and non-enumeration is preserved.
-            """
-            if await auth.repo.get_by_email(db, email) is not None:
-                if email_on:
-                    await _send_best_effort(auth._email_service.notify_existing_account(email))
-                    response.status_code = status.HTTP_202_ACCEPTED
-                    return {"detail": _ENROLLED_DETAIL}
-                raise DuplicateValueException("Email already registered")
-            raise DuplicateValueException("Username already taken")
 
-        if await auth.repo.get_by_email(db, email) is not None or await auth.repo.username_exists(
-            db, username
-        ):
-            return await _on_existing()
+            Note:
+                The trailing "Account already exists" raise is reached only if a
+                collision the caller detected has since vanished (the colliding row
+                was deleted between detection and this re-query) - a rare race, not
+                dead code.
+            """
+            for login_field in login_fields:
+                if await auth.repo.get_by_field(db, login_field, login_values[login_field]) is None:
+                    continue
+                if login_field == "email":
+                    if email_on:
+                        await _send_best_effort(
+                            auth._email_service.notify_existing_account(login_values["email"])
+                        )
+                        response.status_code = status.HTTP_202_ACCEPTED
+                        return {"detail": _ENROLLED_DETAIL}
+                    raise DuplicateValueException("Email already registered")
+                raise DuplicateValueException(f"{login_field.capitalize()} already taken")
+            raise DuplicateValueException("Account already exists")
+
+        for login_field in login_fields:
+            if await auth.repo.get_by_field(db, login_field, login_values[login_field]) is not None:
+                return await _on_existing()
 
         create_data: dict[str, Any] = {
-            "email": email,
-            "username": username,
+            **login_values,
             "hashed_password": get_password_hash(password),
         }
         create_data.update(data)
@@ -142,8 +152,8 @@ def build_register_route(auth: Any, schema: type[BaseModel] | None) -> APIRouter
             await resolve_new_user_fields(
                 auth.new_user_fields,
                 NewUserContext(
-                    email=email,
-                    username=username,
+                    email=login_values.get("email", ""),
+                    username=login_values.get("username", ""),
                     source="register",
                     db=db,
                     register_data=submitted,
@@ -168,8 +178,10 @@ def build_register_route(auth: Any, schema: type[BaseModel] | None) -> APIRouter
             ),
         )
 
-        if email_on:
-            await _send_best_effort(auth._email_service.request_email_verification(db, email))
+        if email_on and auth.repo.has("email"):
+            await _send_best_effort(
+                auth._email_service.request_email_verification(db, auth.repo.get(user, "email"))
+            )
             response.status_code = status.HTTP_202_ACCEPTED
             return {"detail": _ENROLLED_DETAIL}
         return {

--- a/crudauth/repository.py
+++ b/crudauth/repository.py
@@ -12,7 +12,7 @@ import logging
 from collections.abc import Iterable
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import UniqueConstraint, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .constants import (
@@ -41,10 +41,14 @@ class UserRepository:
         model: type[Any],
         column_map: dict[str, str] | None = None,
         register_extra_fields: Iterable[str] | None = None,
+        login_fields: Iterable[str] | None = None,
     ):
         self.model = model
         self.column_map = column_map or {}
         self.register_extra_fields = frozenset(register_extra_fields or ())
+        self.login_fields = (
+            list(login_fields) if login_fields is not None else ["email", "username"]
+        )
         self._warned_provisioning_keys: set[str] = set()
 
     # --- contract translation ------------------------------------------------
@@ -55,6 +59,36 @@ class UserRepository:
     def has(self, logical: str) -> bool:
         """Whether the model actually has the column for ``logical``."""
         return hasattr(self.model, self.col(logical))
+
+    def is_unique_column(self, logical: str) -> bool:
+        """Whether the resolved column for ``logical`` is single-field unique.
+
+        Detects column-level ``unique=True``, a single-column ``UniqueConstraint``,
+        and a single-column unique ``Index`` - all through ``column_map`` (the
+        resolved column name). Composite uniqueness does NOT count: a multi-column
+        unique key doesn't make one field a safe first-match-wins login key, so a
+        composite-only field is treated as non-unique (and the construction check
+        raises for it).
+        """
+        actual = self.col(logical)
+        table = self.model.__table__
+        if actual not in table.columns:
+            return False
+        column = table.columns[actual]
+        if column.unique:
+            return True
+        name = column.name
+        for constraint in table.constraints:
+            if (
+                isinstance(constraint, UniqueConstraint)
+                and len(constraint.columns) == 1
+                and name in constraint.columns.keys()
+            ):
+                return True
+        for index in table.indexes:
+            if index.unique and len(index.columns) == 1 and name in index.columns.keys():
+                return True
+        return False
 
     def get(self, user: Any, logical: str, default: Any = None) -> Any:
         """Read a logical field off ``user``, or ``default`` if the column is absent."""
@@ -105,23 +139,37 @@ class UserRepository:
         result = await db.execute(select(self.model).where(self._attr("id") == coerced))
         return result.scalar_one_or_none()
 
+    async def get_by_field(self, db: AsyncSession, logical: str, value: Any) -> Any | None:
+        """Fetch the user whose ``logical`` field equals ``value``, or ``None``.
+
+        Email is canonicalized before matching (the column is stored canonical);
+        every other field matches as-is.
+        """
+        if logical == "email" and isinstance(value, str):
+            value = canonical_email(value)
+        result = await db.execute(select(self.model).where(self._attr(logical) == value))
+        return result.scalar_one_or_none()
+
     async def get_by_email(self, db: AsyncSession, email: str) -> Any | None:
         """Fetch the user by (canonicalized) email, or ``None``."""
-        result = await db.execute(
-            select(self.model).where(self._attr("email") == canonical_email(email))
-        )
-        return result.scalar_one_or_none()
+        return await self.get_by_field(db, "email", email)
 
     async def get_by_username(self, db: AsyncSession, username: str) -> Any | None:
         """Fetch the user by username, or ``None``."""
-        result = await db.execute(select(self.model).where(self._attr("username") == username))
-        return result.scalar_one_or_none()
+        return await self.get_by_field(db, "username", username)
 
-    async def get_by_identifier(self, db: AsyncSession, identifier: str) -> Any | None:
-        """Look up by email when the identifier contains ``@``, else by username."""
-        if "@" in identifier:
-            return await self.get_by_email(db, identifier)
-        return await self.get_by_username(db, identifier)
+    async def resolve_login(self, db: AsyncSession, identifier: str) -> Any | None:
+        """Resolve a login identifier against ``login_fields``, in order; first match wins.
+
+        Replaces the old ``@``-heuristic: the contract decides which fields a login
+        identifier may match. Safe because every login field is asserted unique at
+        construction, so a match is unambiguous.
+        """
+        for logical in self.login_fields:
+            user = await self.get_by_field(db, logical, identifier)
+            if user is not None:
+                return user
+        return None
 
     async def get_by_oauth(
         self, db: AsyncSession, provider: str, provider_user_id: str

--- a/crudauth/transports/bearer/transport.py
+++ b/crudauth/transports/bearer/transport.py
@@ -204,7 +204,7 @@ class BearerTransport(Transport):
                         "Too many login attempts. Try again later.", retry_after=retry_after
                     )
 
-            user = await runtime.repo.get_by_identifier(db, form_data.username)
+            user = await runtime.repo.resolve_login(db, form_data.username)
             if user is None:
                 dummy_verify_password(form_data.password)
                 raise UnauthorizedException("Incorrect username or password")

--- a/crudauth/transports/session/transport.py
+++ b/crudauth/transports/session/transport.py
@@ -259,7 +259,7 @@ class SessionTransport(Transport):
                     "Too many login attempts. Try again later.", retry_after=retry_after
                 )
 
-            user = await runtime.repo.get_by_identifier(db, form_data.username)
+            user = await runtime.repo.resolve_login(db, form_data.username)
             if user is None:
                 dummy_verify_password(form_data.password)
                 raise UnauthorizedException("Incorrect username or password")

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,390 @@
+"""The identity contract: model-as-truth shape, fail-closed construction validation,
+contract-driven login resolution, email-optional register, recovery-router gating."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sqlalchemy import String, UniqueConstraint
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from crudauth import (
+    AuthUserMixin,
+    CookieConfig,
+    CRUDAuth,
+    EmailConfig,
+    EmailSender,
+    IdentityConfig,
+    SessionTransport,
+    make_auth_identity,
+)
+from crudauth.repository import UserRepository
+from crudauth.utils import get_password_hash
+
+SECRET = "test-secret-key-0123456789-0123456789"
+
+
+class _Sender(EmailSender):
+    async def send(
+        self, *, to, subject, body, kind
+    ) -> None:  # pragma: no cover - never sent in these tests
+        pass
+
+
+# --- model shapes (each its own metadata) ---------------------------------
+
+
+_AnonMixin: Any = make_auth_identity(identifiers=["username"], recovery=None, oauth=False)
+_PhoneMixin: Any = make_auth_identity(identifiers=["username"], recovery="phone", oauth=False)
+_PlainMixin: Any = make_auth_identity(identifiers=["username"], recovery=None, oauth=False)
+_RecoveryEmailMixin: Any = make_auth_identity(
+    identifiers=["username"], recovery="email", oauth=False
+)
+
+
+class _ConstraintBase(DeclarativeBase):
+    pass
+
+
+class ConstraintUser(_ConstraintBase, _PlainMixin):
+    __tablename__ = "constraint_users"
+    phone: Mapped[str | None] = mapped_column(String(32), default=None)  # unique via table arg
+    __table_args__ = (UniqueConstraint("phone"),)
+
+
+class _AnonBase(DeclarativeBase):
+    pass
+
+
+class AnonUser(_AnonBase, _AnonMixin):
+    __tablename__ = "anon_users"
+
+
+class _PhoneBase(DeclarativeBase):
+    pass
+
+
+class PhoneUser(_PhoneBase, _PhoneMixin):
+    __tablename__ = "phone_users"
+    phone: Mapped[str | None] = mapped_column(String(32), unique=True, default=None)
+
+
+class _PhoneBadBase(DeclarativeBase):
+    pass
+
+
+class PhoneBadUser(_PhoneBadBase, _PlainMixin):
+    __tablename__ = "phone_bad_users"
+    phone: Mapped[str | None] = mapped_column(String(32), default=None)  # NOT unique
+
+
+class _CompBase(DeclarativeBase):
+    pass
+
+
+class CompUser(_CompBase, _PlainMixin):
+    __tablename__ = "comp_users"
+    email: Mapped[str | None] = mapped_column(
+        String(320), default=None
+    )  # unique only via composite
+    tenant_id: Mapped[int] = mapped_column(default=0)
+    __table_args__ = (UniqueConstraint("email", "tenant_id"),)
+
+
+def _noop_session() -> None:  # stored by CRUDAuth, never called during construction
+    return None
+
+
+# --- mixin factory --------------------------------------------------------
+
+EXPECTED_DEFAULT_COLUMNS = {
+    "id": ("INTEGER", False, False, True),
+    "email": ("VARCHAR(320)", False, True, False),
+    "username": ("VARCHAR(64)", False, True, False),
+    "hashed_password": ("VARCHAR(255)", False, False, False),
+    "is_active": ("BOOLEAN", False, False, False),
+    "is_superuser": ("BOOLEAN", False, False, False),
+    "email_verified": ("BOOLEAN", False, False, False),
+    "token_version": ("INTEGER", False, False, False),
+    "oauth_provider": ("VARCHAR(32)", True, False, False),
+    "google_id": ("VARCHAR(64)", True, True, False),
+    "github_id": ("VARCHAR(64)", True, True, False),
+    "oauth_created_at": ("DATETIME", True, False, False),
+    "oauth_updated_at": ("DATETIME", True, False, False),
+    "created_at": ("DATETIME", False, False, False),
+    "updated_at": ("DATETIME", True, False, False),
+}
+
+
+def test_default_factory_is_column_identical_to_today() -> None:
+    # The back-compat anchor: make_auth_identity() default must be the exact set of
+    # columns the hand-written AuthUserMixin shipped, or every existing model's
+    # schema silently shifts.
+    class B(DeclarativeBase):
+        pass
+
+    class U(B, AuthUserMixin):
+        __tablename__ = "anchor_users"
+
+    cols = {
+        c.name: (str(c.type), c.nullable, bool(c.unique), c.primary_key)
+        for c in U.__table__.columns
+    }
+    assert cols == EXPECTED_DEFAULT_COLUMNS
+
+
+def test_two_inheritors_get_independent_columns() -> None:
+    # The one place the factory can differ from a hand-written mixin: two models
+    # inheriting the same factory output must each get their own columns.
+    class B(DeclarativeBase):
+        pass
+
+    class U(B, AuthUserMixin):
+        __tablename__ = "ti_users"
+
+    class A(B, AuthUserMixin):
+        __tablename__ = "ti_admins"
+
+    assert len(U.__table__.columns) == len(A.__table__.columns) == 15
+    assert U.__table__.c.email is not A.__table__.c.email
+
+
+def test_anonymous_shape_has_no_email_column() -> None:
+    cols = {c.name for c in AnonUser.__table__.columns}
+    assert "email" not in cols
+    assert {"id", "username", "hashed_password"} <= cols
+
+
+def test_recovery_only_email_is_nullable_and_unique() -> None:
+    # email is the recovery spine but not a login field -> present, nullable, unique.
+    class B(DeclarativeBase):
+        pass
+
+    class U(B, _RecoveryEmailMixin):
+        __tablename__ = "rec_email_users"
+
+    email_col = U.__table__.c.email
+    assert email_col.nullable is True
+    assert bool(email_col.unique) is True
+
+
+def test_is_unique_column_detects_each_form() -> None:
+    # The fail-closed primitive: column-level unique=True, single-column table-level
+    # UniqueConstraint -> unique; a non-unique column and a composite-only field -> not.
+    repo = UserRepository(ConstraintUser)
+    assert repo.is_unique_column("username") is True  # column-level unique=True
+    assert repo.is_unique_column("phone") is True  # single-column UniqueConstraint
+    assert repo.is_unique_column("hashed_password") is False  # not unique
+    assert UserRepository(CompUser).is_unique_column("email") is False  # composite-only
+
+
+# --- construction validation (fail-closed) --------------------------------
+
+
+def _build(model, **kwargs):
+    return CRUDAuth(
+        session=_noop_session,
+        user_model=model,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        **kwargs,
+    )
+
+
+def test_login_field_must_be_a_unique_column() -> None:
+    with pytest.raises(ValueError, match="login field 'phone'"):
+        _build(PhoneBadUser, identity=IdentityConfig(login=["username", "phone"]))
+
+
+def test_recovery_field_must_be_a_unique_column() -> None:
+    with pytest.raises(ValueError, match="recovery field 'phone'"):
+        _build(PhoneBadUser, identity=IdentityConfig(login=["username"], recovery="phone"))
+
+
+def test_recovery_field_must_exist() -> None:
+    with pytest.raises(ValueError, match="recovery field 'phone'"):
+        _build(AnonUser, identity=IdentityConfig(login=["username"], recovery="phone"))
+
+
+def test_composite_only_unique_field_raises() -> None:
+    # email is unique only via a composite UniqueConstraint -> not a safe login key.
+    with pytest.raises(ValueError, match="login field 'email'"):
+        _build(CompUser, identity=IdentityConfig(login=["email"], recovery=None))
+
+
+def test_oauth_requires_email_in_login() -> None:
+    with pytest.raises(ValueError, match="OAuth requires 'email'"):
+        _build(
+            AnonUser,
+            identity=IdentityConfig(login=["username"], recovery=None),
+            oauth={"google": None},
+        )
+
+
+def test_email_config_requires_email_column() -> None:
+    with pytest.raises(ValueError, match="requires an 'email' column"):
+        _build(
+            AnonUser,
+            identity=IdentityConfig(login=["username"], recovery=None),
+            email=EmailConfig(sender=_Sender(), frontend_url="https://app"),
+        )
+
+
+def test_verified_gate_requires_email_column() -> None:
+    auth = _build(AnonUser, identity=IdentityConfig(login=["username"], recovery=None))
+    with pytest.raises(ValueError, match="verified=True"):
+        auth.current_user(verified=True)
+
+
+def test_valid_phone_recovery_shape_constructs() -> None:
+    # unique phone + username login + no email: a fully valid non-default shape.
+    auth = _build(PhoneUser, identity=IdentityConfig(login=["username"], recovery="phone"))
+    assert auth.identity.recovery == "phone"
+
+
+# --- contract-driven login resolution (no @-heuristic) --------------------
+
+
+async def test_login_resolves_by_configured_fields(sessionmaker, UserModel) -> None:
+    repo = UserRepository(UserModel)  # default login=["email","username"]
+    async with sessionmaker() as db:
+        await repo.create(
+            db,
+            {"email": "a@x.com", "username": "alice", "hashed_password": get_password_hash("pw")},
+        )
+    async with sessionmaker() as db:
+        assert repo.user_id(await repo.resolve_login(db, "a@x.com")) is not None
+        assert repo.user_id(await repo.resolve_login(db, "alice")) is not None
+
+
+async def test_username_only_login_does_not_fall_through_to_email(sessionmaker, UserModel) -> None:
+    repo = UserRepository(UserModel, login_fields=["username"])
+    async with sessionmaker() as db:
+        await repo.create(
+            db,
+            {"email": "a@x.com", "username": "alice", "hashed_password": get_password_hash("pw")},
+        )
+    async with sessionmaker() as db:
+        assert await repo.resolve_login(db, "a@x.com") is None  # email is NOT a login field
+        assert await repo.resolve_login(db, "alice") is not None
+
+
+async def test_username_login_is_case_sensitive_and_clean(sessionmaker, UserModel) -> None:
+    # username is matched as-is (no canonicalization), so a wrong-case attempt simply
+    # misses and returns None - a clean failed login, not an error (lockout then keys
+    # on the raw value, consistent with the lookup).
+    repo = UserRepository(UserModel, login_fields=["username"])
+    async with sessionmaker() as db:
+        await repo.create(
+            db,
+            {"email": "b@x.com", "username": "Alice", "hashed_password": get_password_hash("pw")},
+        )
+    async with sessionmaker() as db:
+        assert await repo.resolve_login(db, "alice") is None  # wrong case misses cleanly
+        assert await repo.resolve_login(db, "Alice") is not None
+
+
+# --- email-optional register + recovery gating ----------------------------
+
+
+@asynccontextmanager
+async def _app(model, base, **kwargs) -> AsyncGenerator[tuple, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def get_session() -> AsyncGenerator[AsyncSession, None]:
+        async with maker() as s:
+            yield s
+
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=model,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        **kwargs,
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+    await auth.initialize()
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            yield auth, client, maker
+    finally:
+        await auth.shutdown()
+        await engine.dispose()
+
+
+class _AnonRegister(BaseModel):
+    username: str
+    password: str
+
+
+async def test_register_anonymous_username_only() -> None:
+    identity = IdentityConfig(login=["username"], recovery=None)
+    async with _app(AnonUser, _AnonBase, identity=identity, register_schema=_AnonRegister) as ctx:
+        _auth, client, maker = ctx
+        r = await client.post("/register", json={"username": "neo", "password": "pw123456"})
+        assert r.status_code == 200, r.text  # no email KeyError, no leak
+        repo = UserRepository(AnonUser, login_fields=["username"])
+        async with maker() as db:
+            assert await repo.resolve_login(db, "neo") is not None
+
+
+async def test_register_anonymous_duplicate_username_surfaces() -> None:
+    identity = IdentityConfig(login=["username"], recovery=None)
+    async with _app(AnonUser, _AnonBase, identity=identity, register_schema=_AnonRegister) as ctx:
+        _auth, client, _maker = ctx
+        await client.post("/register", json={"username": "dup", "password": "pw123456"})
+        r = await client.post("/register", json={"username": "dup", "password": "pw123456"})
+        assert r.status_code == 422
+        assert "already taken" in r.text.lower()
+
+
+async def test_recovery_none_omits_recovery_endpoints(get_session, UserModel) -> None:
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=UserModel,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        identity=IdentityConfig(login=["email", "username"], recovery=None),
+        email=EmailConfig(sender=_Sender(), frontend_url="https://app"),
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+    await auth.initialize()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.post("/password/reset-request", json={"email": "a@x.com"})
+        assert r.status_code == 404  # recovery router not mounted
+    await auth.shutdown()
+
+
+async def test_recovery_email_mounts_recovery_endpoints(get_session, UserModel) -> None:
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=UserModel,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        email=EmailConfig(sender=_Sender(), frontend_url="https://app"),
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+    await auth.initialize()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.post("/password/reset-request", json={"email": "a@x.com"})
+        assert r.status_code == 200  # mounted, non-enumerating
+    await auth.shutdown()

--- a/tests/test_new_user_fields.py
+++ b/tests/test_new_user_fields.py
@@ -318,6 +318,9 @@ async def test_suggested_name(sessionmaker) -> None:
         assert oauth_ctx.suggested_name == "Full Name"
         reg_ctx = NewUserContext(email="alice@x.com", username="a", source="register", db=db)
         assert reg_ctx.suggested_name == "alice"
+        # email-less (anonymous) shape falls back to the username, not ""
+        anon_ctx = NewUserContext(email="", username="neo", source="register", db=db)
+        assert anon_ctx.suggested_name == "neo"
 
 
 # --- mass-assignment: neither knob can grant privilege, on either path ----


### PR DESCRIPTION
# Identity contract: model-driven login and recovery, email-optional accounts

crudauth hardcoded email as the identity and recovery spine: the mixin made `email` `NOT NULL` unique, `/register` always popped `email`, login used an `@`-heuristic, and the recovery endpoints assumed email. This branch makes the account's identity shape read from the model (single source of truth), with a thin `IdentityConfig` for the intent a schema can't carry, validated against the model at construction so config that contradicts the model raises at startup. It unblocks three account shapes from one code path: the default (email + username login, email recovery), phone-recovery (username login, phone recovery), and anonymous (username only, no recovery). It is fully additive: the default is column-identical to today's `AuthUserMixin` and the existing suite passes unchanged. This is PR 1 of 2; `verified`/`email_verified` stays email-specific with a guard, and generalizing it to `recovery_verified` is PR 2.

---

## Model-driven identity shape

The model is now the single source of truth for an account's *shape*: which logical columns exist, their nullability, their uniqueness. The hand-written `AuthUserMixin` became a factory, `make_auth_identity(identifiers=, recovery=, oauth=)`, that emits the columns; the runtime reads them back. They can't disagree because they read the same model.

`AuthUserMixin = make_auth_identity()` is the default output and is **column-identical** to the previous hand-written mixin (15 columns, same types, nullability, uniqueness, indexes), proven by an anchor test that asserts the exact column spec. Non-default shapes drop or relax columns: anonymous (`identifiers=["username"], recovery=None`) emits no `email` column at all; recovery-only email (`recovery="email"` without email in `identifiers`) emits a nullable-but-unique `email`. `username`, `hashed_password`, the status flags, `token_version`, and the timestamps are always present; `email` and the oauth-linkage columns are conditional.

**Why a factory and not a config flag:** the column set genuinely differs per shape (an anonymous account has no email column to be NOT NULL), so the difference has to live in the schema the model declares, not in a runtime branch that pretends a column exists.

---

## IdentityConfig, validated against the model at construction

`IdentityConfig(login=[...], recovery=...)` carries only the intent the schema can't express: the order login fields are tried, and which single field recovery is delivered against (or `None` for no recovery). `CRUDAuth.__init__` validates it against the model, fail-closed, so a contradiction is a startup error rather than a silent second source of truth. Five checks, all tested:

- every `login` field must be a single-field unique column;
- `recovery` (when set) must be a single-field unique column;
- OAuth requires `"email"` in `login` (OAuth links and creates by email);
- an email flow (`EmailConfig`) requires an email column;
- `current_user(verified=True)` requires an email column (the placeholder guard).

Uniqueness is detected by `repo.is_unique_column`, which counts column-level `unique=True`, a single-column `UniqueConstraint`, and a single-column unique `Index`, all through `column_map` (the resolved column name). Composite uniqueness deliberately does **not** count: a multi-column unique key doesn't make any one field a safe key, so a composite-only login field raises.

**Why fail-closed:** the safety of first-match-wins login resolution (next section) rests entirely on each login field being unique. If that assertion is soft, an ambiguous match becomes a login-as-the-wrong-user bug, so a non-unique login field has to be a hard error at construction.

---

## Contract-driven login resolution

Login resolution was an `@`-heuristic: contains `@` means email, else username. That can't express "log in by username only" or "log in by phone." It is replaced by `repo.resolve_login`, which tries the contract's `login_fields` in order and takes the first match. The `@`-heuristic (`get_by_identifier`) is removed; `get_by_email` and `get_by_username` now delegate to a shared `get_by_field` (which canonicalizes email and matches every other field as-is). Both the session `/login` and the bearer `/token` call `resolve_login` with the same `form_data.username`, so the two transports resolve identically.

First-match-wins is safe precisely because of the construction-time uniqueness assertion. Username matching stays case-sensitive (no canonicalization), consistent with the lockout key, so a wrong-case username simply misses as a clean failed login.

---

## Email-optional registration and recovery-router gating

`/register` no longer hardcodes email. It pops and existence-checks the contract's `login` fields in one code path: the default pops `{email, username}`, anonymous pops `{username}`. The non-enumeration contract is deliberately asymmetric and preserved: an email collision returns the byte-identical `202` plus owner notice (when email is configured) so it can't be probed, while a non-email login field such as `username` is a public namespace and its collisions surface as `422` "Username already taken" (this is the same thing every signup form's live availability check does, and it is the chosen contract for the anonymous shape).

The recovery router (verify/reset/change) mounts only when `recovery is not None` and a delivery channel exists. With `recovery=None` the endpoints are never built, so an anonymous platform has no reset surface at all.

---

## The `verified` placeholder and a provisioning fix

`current_user(verified=True)` still checks `email_verified` exactly as before; the only addition is the construction guard that it requires an email column. Generalizing this to a transport-agnostic `recovery_verified` is PR 2 and is deliberately not attempted here.

One cross-cutting fix fell out of email-optional accounts: `NewUserContext.suggested_name` (the provisioning seam from the new-user-fields feature) defaulted to the email local-part, which is empty for an account with no email. It now falls back OAuth name, then email local-part, then username, so it stays useful across all three shapes.

---

## Documentation Updates

None in this PR (code only, per the brief). The user-facing guide and Learn-chapter pass for the identity contract is a separate follow-up.

---

## Test Plan

### Automated
- [x] `uv run ruff check crudauth tests` — clean
- [x] `uv run mypy crudauth tests --config-file pyproject.toml` — clean (99 files)
- [x] `uv run pytest` — 283 passed (263 pre-existing unchanged, the back-compat proof)

### Model-driven shape
- [x] `make_auth_identity()` default is column-identical to the prior `AuthUserMixin` (column-by-column)
- [x] Two models inheriting the default get independent columns (the one place a factory can differ from a hand-written mixin)
- [x] Anonymous shape (`identifiers=["username"], recovery=None`) emits no email column
- [x] Recovery-only email (`recovery="email"`, not a login field) is nullable and unique

### Construction validation
- [x] `is_unique_column` detects column-level `unique=True`, single-column `UniqueConstraint`; rejects non-unique and composite-only
- [x] Raises: non-unique login field, non-unique/missing recovery field, composite-only login field, OAuth without email in login, EmailConfig without an email column, `verified=True` gate without an email column
- [x] A valid phone-recovery shape (unique phone, username login) constructs

### Login resolution
- [x] Resolves by configured fields in order; username-only login does not fall through to email
- [x] Username matching is case-sensitive and misses cleanly (no error), consistent with the lockout key

### Register + recovery gating
- [x] Anonymous register (username only) succeeds with no email KeyError; duplicate username surfaces `422`
- [x] Existing email register stays non-enumerable (`202`), suite unchanged
- [x] `recovery=None` omits the recovery endpoints; `recovery="email"` mounts them

### Provisioning fix
- [x] `suggested_name` falls back to username for an email-less context

---

## Dependencies

None new.

## Breaking Changes

- **`UserRepository.get_by_identifier` removed.** The `@`-heuristic is replaced by `resolve_login` (contract-driven). Any code calling `repo.get_by_identifier` directly will fail at call time; use `repo.resolve_login` (or `repo.get_by_field` for a specific field). `get_by_email`/`get_by_username` are unchanged.
- **`AuthUserMixin` is now produced by `make_auth_identity()` rather than a hand-written class.** This is **not** a schema change: the default output is column-identical (asserted by the anchor test), so existing `class User(Base, AuthUserMixin)` models are byte-identical. Called out only because the symbol's definition changed from a class to a factory result.
- New optional constructor argument `CRUDAuth(identity=IdentityConfig(...))` and a new `login_fields` argument on `UserRepository`; both default to today's behavior, so existing configurations are unaffected. New public exports: `IdentityConfig`, `make_auth_identity` (and `AuthUserMixin` now also at the top level).
