### PR TITLE
Recovery-factor verification: "verified" means the recovery factor, email is the special case

### DIFF
--- a/crudauth/core.py
+++ b/crudauth/core.py
@@ -17,7 +17,6 @@ from fastapi import APIRouter, Request
 from .constants import DEFAULT_ALGORITHM
 from .principal import Principal
 
-# Valid SameSite cookie values, matching Starlette's set_cookie signature.
 SameSite = Literal["lax", "strict", "none"]
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -127,6 +126,7 @@ class AuthContext:
             user=user,
             is_superuser=self.repo.is_superuser(user) if user is not None else False,
             email_verified=self.repo.email_verified(user) if user is not None else False,
+            recovery_verified=self.repo.recovery_verified(user) if user is not None else False,
             metadata=metadata or {},
         )
 

--- a/crudauth/crud_auth.py
+++ b/crudauth/crud_auth.py
@@ -205,7 +205,11 @@ class CRUDAuth:
         self.session = session
         self.identity = identity or IdentityConfig()
         self.repo = UserRepository(
-            user_model, column_map, register_extra_fields, login_fields=self.identity.login
+            user_model,
+            column_map,
+            register_extra_fields,
+            login_fields=self.identity.login,
+            recovery=self.identity.recovery,
         )
         self._validate_identity(oauth=oauth, email=email)
         self.new_user_fields = new_user_fields
@@ -552,10 +556,10 @@ class CRUDAuth:
                 ...
             ```
         """
-        if verified and not self.repo.has("email"):
+        if verified and self.identity.recovery is None:
             raise ValueError(
-                "current_user(verified=True) gates on email_verified, which requires an "
-                "email column on the user model. (PR-1 placeholder; recovery_verified is PR 2.)"
+                "current_user(verified=True) requires a recovery factor (identity.recovery); "
+                "an account shape with no recovery has nothing to prove control of."
             )
         selected = self._select_transports(transport)
         required_scopes = list(scopes or [])
@@ -572,8 +576,8 @@ class CRUDAuth:
 
             if superuser and not principal.is_superuser:
                 raise ForbiddenException("Insufficient privileges")
-            if verified and not principal.email_verified:
-                raise ForbiddenException("Email not verified")
+            if verified and not principal.recovery_verified:
+                raise ForbiddenException("Recovery factor not verified")
             if required_scopes and not principal.has_scopes(required_scopes):
                 raise ForbiddenException("Insufficient scope")
             if check is not None:

--- a/crudauth/email/channel.py
+++ b/crudauth/email/channel.py
@@ -41,8 +41,10 @@ class DeliveryIntent:
     copy. Read what you need off ``recipient`` / ``user``; do not assume email.
 
     Attributes:
-        kind: Which message this is (``verify_email`` / ``reset_password`` /
-            ``change_email`` / ``existing_account``).
+        kind: Which message this is (``verify_email`` for an email-recovery verify,
+            ``verify_recovery`` for any other factor, ``reset_password`` /
+            ``change_email`` / ``existing_account``). A non-email channel branches on
+            this to pick its own medium-appropriate copy.
         token: The signed token, or ``None`` for ``existing_account`` (a notice
             with no action).
         user: The logical-contract user dict (``repo.to_dict``); empty for the
@@ -102,6 +104,7 @@ class DeliveryChannel(ABC):
 # kind -> (subject, EmailConfig path attribute, body prefix) for the link kinds.
 _EMAIL_SPECS: dict[str, tuple[str, str, str]] = {
     "verify_email": (SUBJECT_VERIFY, "verify_path", "Verify your email:"),
+    "verify_recovery": (SUBJECT_VERIFY, "verify_path", "Verify your email:"),
     "reset_password": (SUBJECT_RESET, "reset_path", "Reset your password:"),
     "change_email": (SUBJECT_CHANGE, "change_path", "Confirm your new email:"),
 }

--- a/crudauth/email/constants.py
+++ b/crudauth/email/constants.py
@@ -9,11 +9,19 @@ VERIFY = "verify_email"
 RESET = "reset_password"
 CHANGE = "change_email"
 
-# The message kinds crudauth asks the adapter to deliver. ``existing_account`` is
-# a security notice ("someone tried to register with your email"), distinct from
-# the cheery ``welcome``. (The first three mirror VERIFY/RESET/CHANGE above;
-# Literal members must be string literals, so they're spelled out here.)
-EmailKind = Literal["verify_email", "reset_password", "change_email", "welcome", "existing_account"]
+# The message kinds crudauth asks the adapter to deliver. ``verify_email`` is the
+# recovery-factor verification for an email-recovery app; ``verify_recovery`` is the
+# same for any other factor (so a non-email channel isn't handed an "email"-named
+# kind). ``existing_account`` is a security notice ("someone tried to register with
+# your email"), distinct from the cheery ``welcome``.
+EmailKind = Literal[
+    "verify_email",
+    "verify_recovery",
+    "reset_password",
+    "change_email",
+    "welcome",
+    "existing_account",
+]
 EMAIL_KINDS: tuple[EmailKind, ...] = get_args(EmailKind)
 
 # Per-target-email throttle actions -> the rate_limits keys they borrow.

--- a/crudauth/email/router.py
+++ b/crudauth/email/router.py
@@ -56,13 +56,13 @@ def build_email_router(*, auth: Any, service: EmailFlowService) -> APIRouter:
     )
     async def request_verification(body: _EmailIn, db: Annotated[Any, Depends(db_dep)]):
         """Send an email-verification link. Always returns success (no enumeration)."""
-        await service.request_email_verification(db, body.email)
+        await service.request_recovery_verification(db, body.email)
         return {"detail": "If an account exists, a verification email has been sent."}
 
     @router.post("/email/verify-confirm")
     async def confirm_verification(body: _TokenIn, db: Annotated[Any, Depends(db_dep)]):
         """Confirm a verification token and mark the email verified."""
-        await service.confirm_email_verification(db, body.token)
+        await service.confirm_recovery_verification(db, body.token)
         return {"detail": "Email verified successfully."}
 
     @router.post(

--- a/crudauth/email/service.py
+++ b/crudauth/email/service.py
@@ -205,13 +205,21 @@ class EmailFlowService:
             None,
         )
 
-    # --- email verification --------------------------------------------------
-    async def request_email_verification(self, db: AsyncSession, email: str) -> None:
-        """Send a verification link. Idempotent; never reveals account existence."""
-        if not await self._email_within_limit(VERIFY_ACTION, email):
+    # --- recovery-factor verification ----------------------------------------
+    async def request_email_verification(self, db: AsyncSession, value: str) -> None:
+        """Send a verification token for the contract's recovery factor.
+
+        Idempotent; never reveals account existence. The user is looked up by the
+        recovery factor (email for email recovery, phone for phone recovery) and
+        the token is delivered to that factor's value over the configured channel.
+        """
+        factor = self.repo.recovery
+        if factor is None:
             return
-        user = await self.repo.get_by_email(db, email)
-        if user is None or self.repo.email_verified(user):
+        if not await self._email_within_limit(VERIFY_ACTION, value):
+            return
+        user = await self.repo.get_by_field(db, factor, value)
+        if user is None or self.repo.recovery_verified(user):
             return
         token = create_signed_token(
             self.secret_key,
@@ -222,10 +230,10 @@ class EmailFlowService:
         )
         await self._deliver(
             DeliveryIntent(
-                kind="verify_email",
+                kind="verify_email" if factor == "email" else "verify_recovery",
                 token=token,
                 user=self.repo.to_dict(user),
-                recipient=email,
+                recipient=self.repo.get(user, factor),
                 expires_in=self.verify_ttl_hours * SECONDS_PER_HOUR,
             ),
             db,
@@ -252,19 +260,23 @@ class EmailFlowService:
         user = await self.repo.get_by_id(db, sub)
         if user is None:
             raise BadRequestException("Invalid or expired token")
-        if not self.repo.email_verified(user):
-            await self.repo.update(db, user, {"email_verified": True})
+        if not self.repo.recovery_verified(user):
+            await self.repo.mark_recovery_verified(db, user)
             await self.hooks.run_after_email_verified(
                 self.repo.to_dict(user), db=db, context=HookContext()
             )
         return user
 
     # --- password reset ------------------------------------------------------
-    async def request_password_reset(self, db: AsyncSession, email: str) -> None:
-        """Send a reset link. Idempotent; never reveals account existence."""
-        if not await self._email_within_limit(RESET_ACTION, email):
+    async def request_password_reset(self, db: AsyncSession, value: str) -> None:
+        """Send a reset token over the configured channel. Idempotent; never reveals
+        account existence. Looked up by, and delivered to, the recovery factor."""
+        factor = self.repo.recovery
+        if factor is None:
             return
-        user = await self.repo.get_by_email(db, email)
+        if not await self._email_within_limit(RESET_ACTION, value):
+            return
+        user = await self.repo.get_by_field(db, factor, value)
         if user is None:
             return
         token = create_signed_token(
@@ -279,7 +291,7 @@ class EmailFlowService:
                 kind="reset_password",
                 token=token,
                 user=self.repo.to_dict(user),
-                recipient=email,
+                recipient=self.repo.get(user, factor),
                 expires_in=self.reset_ttl_hours * SECONDS_PER_HOUR,
             ),
             db,

--- a/crudauth/email/service.py
+++ b/crudauth/email/service.py
@@ -262,7 +262,7 @@ class EmailFlowService:
             raise BadRequestException("Invalid or expired token")
         if not self.repo.recovery_verified(user):
             await self.repo.mark_recovery_verified(db, user)
-            await self.hooks.run_after_email_verified(
+            await self.hooks.run_after_recovery_verified(
                 self.repo.to_dict(user), db=db, context=HookContext()
             )
         return user

--- a/crudauth/email/service.py
+++ b/crudauth/email/service.py
@@ -206,7 +206,7 @@ class EmailFlowService:
         )
 
     # --- recovery-factor verification ----------------------------------------
-    async def request_email_verification(self, db: AsyncSession, value: str) -> None:
+    async def request_recovery_verification(self, db: AsyncSession, value: str) -> None:
         """Send a verification token for the contract's recovery factor.
 
         Idempotent; never reveals account existence. The user is looked up by the
@@ -239,7 +239,7 @@ class EmailFlowService:
             db,
         )
 
-    async def confirm_email_verification(self, db: AsyncSession, token: str) -> Any:
+    async def confirm_recovery_verification(self, db: AsyncSession, token: str) -> Any:
         """Verify the signed token and mark the user's email verified (one-time-use).
 
         Args:

--- a/crudauth/hooks.py
+++ b/crudauth/hooks.py
@@ -53,7 +53,7 @@ class AuthHooks:
     on_after_register: Hook | None = None
     on_after_login: Hook | None = None
     on_after_logout: Hook | None = None
-    on_after_email_verified: Hook | None = None
+    on_after_recovery_verified: Hook | None = None
     on_after_password_reset: Hook | None = None
     on_after_email_changed: Hook | None = None
     on_after_sudo: Hook | None = None
@@ -70,9 +70,11 @@ class AuthHooks:
         if self.on_after_logout is not None:
             await _maybe_await(self.on_after_logout(user, request=request, context=context))
 
-    async def run_after_email_verified(self, user: dict, *, db: Any, context: HookContext) -> None:
-        if self.on_after_email_verified is not None:
-            await _maybe_await(self.on_after_email_verified(user, db=db, context=context))
+    async def run_after_recovery_verified(
+        self, user: dict, *, db: Any, context: HookContext
+    ) -> None:
+        if self.on_after_recovery_verified is not None:
+            await _maybe_await(self.on_after_recovery_verified(user, db=db, context=context))
 
     async def run_after_password_reset(self, user: dict, *, db: Any, context: HookContext) -> None:
         if self.on_after_password_reset is not None:

--- a/crudauth/models/mixin.py
+++ b/crudauth/models/mixin.py
@@ -42,9 +42,12 @@ def make_auth_identity(
         identifiers: Logical fields a user may log in with. Each becomes a
             ``NOT NULL`` unique column. ``email`` here makes the email column
             required.
-        recovery: The single field recovery (verify/reset/change) is delivered
-            against, or ``None`` for an account shape with no recovery. ``"email"``
-            (and not an identifier) makes the email column nullable but unique.
+        recovery: The single field recovery (verify/reset) is delivered against,
+            or ``None`` for an account shape with no recovery. ``"email"`` (and not
+            an identifier) makes the email column nullable but unique. A non-email
+            factor emits a ``{factor}_verified`` bookkeeping flag (e.g.
+            ``phone_verified``); you still declare the factor column itself (e.g.
+            ``phone``) with your own constraints, the same way you would any column.
         oauth: Emit the oauth-linkage columns (``oauth_provider`` / ``google_id`` /
             ``github_id`` / timestamps). Required for OAuth login.
 
@@ -91,6 +94,9 @@ def make_auth_identity(
     add("is_superuser", Mapped[bool], mapped_column(default=False))
     add("email_verified", Mapped[bool], mapped_column(default=False))
     add("token_version", Mapped[int], mapped_column(default=0))
+
+    if recovery is not None and recovery != "email":
+        add(f"{recovery}_verified", Mapped[bool], mapped_column(default=False))
 
     if oauth:
         add("oauth_provider", Mapped[str | None], mapped_column(String(32), default=None))

--- a/crudauth/principal.py
+++ b/crudauth/principal.py
@@ -25,7 +25,14 @@ class Principal:
         user: The resolved user row (your ``User`` ORM instance), or ``None`` if
             a transport chose not to resolve it.
         is_superuser: Whether the user holds the superuser flag.
-        email_verified: Whether the user's email is verified.
+        email_verified: The email-specific verified value. Do NOT gate on this -
+            it is ``False`` on a non-email-recovery account (there is no email), so
+            ``check=lambda p: p.email_verified`` silently always-denies a phone app.
+            For gating use ``current_user(verified=True)`` / ``recovery_verified``;
+            ``email_verified`` equals ``recovery_verified`` only when recovery is email.
+        recovery_verified: Whether the contract's recovery factor is proven
+            controlled. This is what ``current_user(verified=True)`` gates on -
+            email is the special case, an arbitrary factor (e.g. phone) the general.
 
     Example:
         ```python
@@ -41,6 +48,7 @@ class Principal:
     user: Any = None
     is_superuser: bool = False
     email_verified: bool = False
+    recovery_verified: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def has_scopes(self, required: list[str] | tuple[str, ...]) -> bool:

--- a/crudauth/register/route.py
+++ b/crudauth/register/route.py
@@ -178,9 +178,11 @@ def build_register_route(auth: Any, schema: type[BaseModel] | None) -> APIRouter
             ),
         )
 
-        if email_on and auth.repo.has("email"):
+        if email_on and auth.identity.recovery is not None:
             await _send_best_effort(
-                auth._email_service.request_email_verification(db, auth.repo.get(user, "email"))
+                auth._email_service.request_email_verification(
+                    db, auth.repo.get(user, auth.identity.recovery)
+                )
             )
             response.status_code = status.HTTP_202_ACCEPTED
             return {"detail": _ENROLLED_DETAIL}

--- a/crudauth/register/route.py
+++ b/crudauth/register/route.py
@@ -180,7 +180,7 @@ def build_register_route(auth: Any, schema: type[BaseModel] | None) -> APIRouter
 
         if email_on and auth.identity.recovery is not None:
             await _send_best_effort(
-                auth._email_service.request_email_verification(
+                auth._email_service.request_recovery_verification(
                     db, auth.repo.get(user, auth.identity.recovery)
                 )
             )

--- a/crudauth/repository.py
+++ b/crudauth/repository.py
@@ -42,6 +42,7 @@ class UserRepository:
         column_map: dict[str, str] | None = None,
         register_extra_fields: Iterable[str] | None = None,
         login_fields: Iterable[str] | None = None,
+        recovery: str | None = "email",
     ):
         self.model = model
         self.column_map = column_map or {}
@@ -49,7 +50,18 @@ class UserRepository:
         self.login_fields = (
             list(login_fields) if login_fields is not None else ["email", "username"]
         )
+        self.recovery = recovery
         self._warned_provisioning_keys: set[str] = set()
+
+    def _recovery_verified_col(self) -> str | None:
+        """The column backing the recovery-factor verified flag, or ``None``.
+
+        Email recovery reuses the always-present ``email_verified``; any other
+        factor uses ``{factor}_verified``. ``recovery=None`` has no such column.
+        """
+        if self.recovery is None:
+            return None
+        return "email_verified" if self.recovery == "email" else f"{self.recovery}_verified"
 
     # --- contract translation ------------------------------------------------
     def col(self, logical: str) -> str:
@@ -200,8 +212,16 @@ class UserRepository:
         ``column_map`` that renames ``is_superuser`` to ``is_admin`` plus a
         register schema declaring ``is_admin`` would otherwise slip a gated
         field past a logical-only gate.
+
+        The recovery-factor verified column (e.g. ``phone_verified``) is gated
+        too - it must be as unsettable at signup as ``email_verified`` always was,
+        since "verified" may only be set by returning the delivered token.
         """
-        return set(REGISTRATION_GATED_FIELDS) | {self.col(g) for g in REGISTRATION_GATED_FIELDS}
+        gated = set(REGISTRATION_GATED_FIELDS) | {self.col(g) for g in REGISTRATION_GATED_FIELDS}
+        rv = self._recovery_verified_col()
+        if rv is not None:
+            gated.add(rv)
+        return gated
 
     def _allowed_register_names(self) -> set[str]:
         """Names registration may keep: the base allowlist plus opted-in extras,
@@ -247,8 +267,14 @@ class UserRepository:
         return {k: v for k, v in data.items() if k in allowed and k not in gated}
 
     def _contract_names(self) -> set[str]:
-        """Every crudauth logical field, by logical AND mapped column name."""
-        return set(LOGICAL_FIELDS) | {self.col(f) for f in LOGICAL_FIELDS}
+        """Every crudauth logical field, by logical AND mapped column name, plus the
+        recovery-factor verified column (so a ``new_user_fields`` callback can't set
+        ``{factor}_verified`` any more than it can set ``email_verified``)."""
+        names = set(LOGICAL_FIELDS) | {self.col(f) for f in LOGICAL_FIELDS}
+        rv = self._recovery_verified_col()
+        if rv is not None:
+            names.add(rv)
+        return names
 
     def filter_provisioning_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Keep only app columns from a ``new_user_fields`` callback.
@@ -331,6 +357,25 @@ class UserRepository:
 
     def email_verified(self, user: Any) -> bool:
         return bool(self.get(user, "email_verified", False))
+
+    def recovery_verified(self, user: Any) -> bool:
+        """Whether the contract's recovery factor is proven controlled.
+
+        Email recovery reads ``email_verified``; another factor reads
+        ``{factor}_verified``; ``recovery=None`` is never verified. This is the
+        general meaning of "verified" - email is the special case, not the concept.
+        """
+        col = self._recovery_verified_col()
+        if col is None or not self.has(col):
+            return False
+        return bool(self.get(user, col, False))
+
+    async def mark_recovery_verified(self, db: AsyncSession, user: Any) -> None:
+        """Set the contract's recovery-factor verified flag (the verify-flow write)."""
+        col = self._recovery_verified_col()
+        if col is None:
+            return
+        await self.update(db, user, {col: True})
 
     def is_active(self, user: Any) -> bool:
         if not self.has("is_active"):

--- a/docs/guides/accounts/email.md
+++ b/docs/guides/accounts/email.md
@@ -125,7 +125,7 @@ know:
 
 ## Hooks
 
-`on_after_email_verified`, `on_after_password_reset`, and `on_after_email_changed` fire after
+`on_after_recovery_verified`, `on_after_password_reset`, and `on_after_email_changed` fire after
 the matching confirm, so you can grant access, send a notice, or write an audit record.
 
 ## Security notes

--- a/docs/guides/infra/hooks.md
+++ b/docs/guides/infra/hooks.md
@@ -24,7 +24,7 @@ your hooks don't couple to the model.
 | `on_after_register` | an account is created | `user, db, context` |
 | `on_after_login` | a successful login | `user, request, context` |
 | `on_after_logout` | a logout | `user, request, context` |
-| `on_after_email_verified` | email verification confirm | `user, db, context` |
+| `on_after_recovery_verified` | recovery-factor verification confirm | `user, db, context` |
 | `on_after_password_reset` | password reset confirm | `user, db, context` |
 | `on_after_email_changed` | email change confirm | `user, db, context` |
 | `on_after_sudo` | a sudo elevation | `user, request, context` |

--- a/tests/email/test_channels.py
+++ b/tests/email/test_channels.py
@@ -247,7 +247,7 @@ async def test_intent_shapes_per_kind(sessionmaker, UserModel) -> None:
     )
     async with sessionmaker() as db:
         user = await repo.get_by_email(db, "u@x.com")
-        await svc.request_email_verification(db, "u@x.com")
+        await svc.request_recovery_verification(db, "u@x.com")
         await svc.request_password_reset(db, "u@x.com")
         await svc.request_email_change(db, user, "new@x.com", "pw")
         await svc.notify_existing_account("u@x.com")

--- a/tests/test_recovery_verification.py
+++ b/tests/test_recovery_verification.py
@@ -227,6 +227,23 @@ async def test_phone_verify_delivers_to_phone_and_gates_on_it() -> None:
         assert (await client.get("/secret")).status_code == 200  # now verified
 
 
+async def test_phone_reset_delivers_to_the_phone() -> None:
+    # password reset re-points to the recovery factor too, not just verify: the
+    # reset token is delivered to the phone, the same generalization as verify.
+    async with _phone_app() as (auth, _client, maker, channel):
+        repo = auth.repo
+        async with maker() as db:
+            await repo.create(
+                db,
+                {"username": "morph", "phone": "999", "hashed_password": get_password_hash("pw")},
+            )
+        async with maker() as db:
+            await auth._email_service.request_password_reset(db, "999")
+        intent = channel.intents[-1]
+        assert intent.recipient == "999"  # delivered to the phone, not an email
+        assert intent.kind == "reset_password" and intent.token is not None
+
+
 async def test_phone_verify_requires_the_delivered_token() -> None:
     async with _phone_app() as (auth, _client, maker, channel):
         repo = auth.repo

--- a/tests/test_recovery_verification.py
+++ b/tests/test_recovery_verification.py
@@ -1,0 +1,255 @@
+"""Recovery-verification generalization: "verified" means proof of control of the
+contract's recovery factor; email is the special case. Same proof machinery (signed
+one-time token returned over the channel) for any factor - only the delivery channel
+and the verified column change. The flag must stay as unsettable as email_verified."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import Depends, FastAPI
+from sqlalchemy import String
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from crudauth import (
+    AuthUserMixin,
+    CookieConfig,
+    CRUDAuth,
+    DeliveryChannel,
+    DeliveryIntent,
+    IdentityConfig,
+    Principal,
+    SessionTransport,
+    make_auth_identity,
+)
+from crudauth.exceptions import BadRequestException
+from crudauth.repository import UserRepository
+from crudauth.utils import get_password_hash
+
+SECRET = "test-secret-key-0123456789-0123456789"
+
+_PhoneMixin: Any = make_auth_identity(identifiers=["username"], recovery="phone", oauth=False)
+
+
+class _PhoneBase(DeclarativeBase):
+    pass
+
+
+class PhoneUser(_PhoneBase, _PhoneMixin):
+    __tablename__ = "rv_phone_users"
+    phone: Mapped[str | None] = mapped_column(String(32), unique=True, default=None)
+
+
+class RecordingChannel(DeliveryChannel):
+    def __init__(self) -> None:
+        self.intents: list[DeliveryIntent] = []
+
+    async def deliver(self, intent: DeliveryIntent, db) -> None:
+        self.intents.append(intent)
+
+
+# --- mixin factory: {factor}_verified -------------------------------------
+
+
+def test_factory_emits_phone_verified() -> None:
+    assert "phone_verified" in {c.name for c in PhoneUser.__table__.columns}
+
+
+def test_factory_does_not_double_emit_email_verified() -> None:
+    class B(DeclarativeBase):
+        pass
+
+    class U(B, AuthUserMixin):
+        __tablename__ = "rv_default_users"
+
+    names = [c.name for c in U.__table__.columns]
+    assert names.count("email_verified") == 1
+
+
+def test_factory_anonymous_emits_no_extra_verified_flag() -> None:
+    anon: Any = make_auth_identity(identifiers=["username"], recovery=None, oauth=False)
+
+    class B(DeclarativeBase):
+        pass
+
+    class U(B, anon):
+        __tablename__ = "rv_anon_users"
+
+    extra = [
+        c.name
+        for c in U.__table__.columns
+        if c.name.endswith("_verified") and c.name != "email_verified"
+    ]
+    assert extra == []
+
+
+# --- recovery_verified reads the right column per factor -------------------
+
+
+def test_recovery_verified_reads_right_column_per_factor(UserModel) -> None:
+    email_repo = UserRepository(UserModel)  # default recovery="email"
+    u = UserModel()
+    u.email_verified = True
+    assert email_repo.recovery_verified(u) is True
+    u.email_verified = False
+    assert email_repo.recovery_verified(u) is False
+
+    phone_repo = UserRepository(PhoneUser, recovery="phone")
+    p = PhoneUser()
+    p.phone_verified = True
+    assert phone_repo.recovery_verified(p) is True
+    p.phone_verified = False
+    assert phone_repo.recovery_verified(p) is False
+
+    none_repo = UserRepository(PhoneUser, recovery=None)
+    p.phone_verified = True
+    assert none_repo.recovery_verified(p) is False  # no recovery factor -> never verified
+
+
+def test_email_recovery_equals_email_verified(UserModel) -> None:
+    # email is the special case: recovery_verified reads email_verified for an email app.
+    repo = UserRepository(UserModel)
+    u = UserModel()
+    u.email_verified = True
+    assert repo.recovery_verified(u) is True and repo.email_verified(u) is True
+
+
+# --- the flag is as unsettable as email_verified (three write paths) -------
+
+
+def test_factor_verified_unsettable_via_register_and_provisioning() -> None:
+    # (1) register: even opted into register_extra_fields, the verified flag is gated
+    reg_repo = UserRepository(PhoneUser, register_extra_fields={"phone_verified"}, recovery="phone")
+    assert "phone_verified" not in reg_repo.filter_registration_data(
+        {"username": "u", "phone_verified": True}
+    )
+    # (2) new_user_fields callback flows through filter_provisioning_data -> dropped
+    prov_repo = UserRepository(PhoneUser, recovery="phone")
+    assert prov_repo.filter_provisioning_data({"phone": "1", "phone_verified": True}) == {
+        "phone": "1"
+    }
+
+
+def test_factor_verified_unsettable_via_new_user_defaults(get_session) -> None:
+    # (3) new_user_defaults is gated at construction
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=PhoneUser,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        identity=IdentityConfig(login=["username"], recovery="phone"),
+        new_user_defaults={"phone_verified": True, "phone": "x"},
+    )
+    assert "phone_verified" not in auth._new_user_defaults
+    assert auth._new_user_defaults == {"phone": "x"}
+
+
+# --- the gate flips to the recovery factor --------------------------------
+
+
+def test_verified_gate_requires_recovery_factor(get_session, UserModel) -> None:
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=UserModel,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        identity=IdentityConfig(login=["email", "username"], recovery=None),
+    )
+    with pytest.raises(ValueError, match="recovery factor"):
+        auth.current_user(verified=True)
+
+
+# --- the proof: phone verify is the same machinery, re-pointed ------------
+
+
+@asynccontextmanager
+async def _phone_app() -> AsyncGenerator[tuple, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(_PhoneBase.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def get_session() -> AsyncGenerator[AsyncSession, None]:
+        async with maker() as s:
+            yield s
+
+    channel = RecordingChannel()
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=PhoneUser,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        identity=IdentityConfig(login=["username"], recovery="phone"),
+        channels=[channel],
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+
+    @app.get("/secret")
+    async def secret(_: Principal = Depends(auth.current_user(verified=True))):
+        return {"ok": True}
+
+    await auth.initialize()
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            yield auth, client, maker, channel
+    finally:
+        await auth.shutdown()
+        await engine.dispose()
+
+
+async def test_phone_verify_delivers_to_phone_and_gates_on_it() -> None:
+    async with _phone_app() as (auth, client, maker, channel):
+        repo = auth.repo
+        async with maker() as db:
+            await repo.create(
+                db, {"username": "neo", "phone": "555", "hashed_password": get_password_hash("pw")}
+            )
+        await client.post("/login", data={"username": "neo", "password": "pw"})
+        assert (await client.get("/secret")).status_code == 403  # not verified yet
+
+        async with maker() as db:
+            await auth._email_service.request_email_verification(db, "555")
+        intent = channel.intents[-1]
+        assert intent.recipient == "555"  # delivered to the PHONE, not an email
+        # factor-neutral kind for a non-email factor (not the email-named "verify_email")
+        assert intent.kind == "verify_recovery" and intent.token is not None
+
+        async with maker() as db:
+            await auth._email_service.confirm_email_verification(db, intent.token)
+        assert (await client.get("/secret")).status_code == 200  # now verified
+
+
+async def test_phone_verify_requires_the_delivered_token() -> None:
+    async with _phone_app() as (auth, _client, maker, channel):
+        repo = auth.repo
+        async with maker() as db:
+            await repo.create(
+                db,
+                {"username": "trin", "phone": "777", "hashed_password": get_password_hash("pw")},
+            )
+        async with maker() as db:
+            await auth._email_service.request_email_verification(db, "777")
+        token = channel.intents[-1].token
+        assert token is not None
+
+        async with maker() as db:
+            with pytest.raises(BadRequestException):
+                await auth._email_service.confirm_email_verification(db, "not-a-token")
+            assert repo.recovery_verified(await repo.get_by_field(db, "phone", "777")) is False
+
+        async with maker() as db:
+            await auth._email_service.confirm_email_verification(db, token)
+            assert repo.recovery_verified(await repo.get_by_field(db, "phone", "777")) is True
+
+        async with maker() as db:
+            with pytest.raises(BadRequestException):
+                await auth._email_service.confirm_email_verification(db, token)  # replay rejected
+            assert repo.recovery_verified(await repo.get_by_field(db, "phone", "777")) is True

--- a/tests/test_recovery_verification.py
+++ b/tests/test_recovery_verification.py
@@ -216,14 +216,14 @@ async def test_phone_verify_delivers_to_phone_and_gates_on_it() -> None:
         assert (await client.get("/secret")).status_code == 403  # not verified yet
 
         async with maker() as db:
-            await auth._email_service.request_email_verification(db, "555")
+            await auth._email_service.request_recovery_verification(db, "555")
         intent = channel.intents[-1]
         assert intent.recipient == "555"  # delivered to the PHONE, not an email
         # factor-neutral kind for a non-email factor (not the email-named "verify_email")
         assert intent.kind == "verify_recovery" and intent.token is not None
 
         async with maker() as db:
-            await auth._email_service.confirm_email_verification(db, intent.token)
+            await auth._email_service.confirm_recovery_verification(db, intent.token)
         assert (await client.get("/secret")).status_code == 200  # now verified
 
 
@@ -236,20 +236,22 @@ async def test_phone_verify_requires_the_delivered_token() -> None:
                 {"username": "trin", "phone": "777", "hashed_password": get_password_hash("pw")},
             )
         async with maker() as db:
-            await auth._email_service.request_email_verification(db, "777")
+            await auth._email_service.request_recovery_verification(db, "777")
         token = channel.intents[-1].token
         assert token is not None
 
         async with maker() as db:
             with pytest.raises(BadRequestException):
-                await auth._email_service.confirm_email_verification(db, "not-a-token")
+                await auth._email_service.confirm_recovery_verification(db, "not-a-token")
             assert repo.recovery_verified(await repo.get_by_field(db, "phone", "777")) is False
 
         async with maker() as db:
-            await auth._email_service.confirm_email_verification(db, token)
+            await auth._email_service.confirm_recovery_verification(db, token)
             assert repo.recovery_verified(await repo.get_by_field(db, "phone", "777")) is True
 
         async with maker() as db:
             with pytest.raises(BadRequestException):
-                await auth._email_service.confirm_email_verification(db, token)  # replay rejected
+                await auth._email_service.confirm_recovery_verification(
+                    db, token
+                )  # replay rejected
             assert repo.recovery_verified(await repo.get_by_field(db, "phone", "777")) is True


### PR DESCRIPTION
# Recovery-factor verification: "verified" means the recovery factor, email is the special case

PR 1 made identity and recovery shape model-driven (`recovery="email" | "phone" | None`), but `verified` stayed email-specific: `current_user(verified=True)` checked `email_verified`, and configuring that gate without an email column *raised*. This PR generalizes "verified" to mean "the contract's recovery factor is proven controlled," so a phone-recovery app verifies by SMS, with `email_verified` becoming the special case where the factor is email. The proof flow is the same signed-one-time-token machinery, re-pointed at the factor and its channel; the security core is untouched; and the public surface is renamed so its names tell the truth. This is PR 2 of 2, closing the identity-and-recovery arc; the existing email suite passes unchanged.

---

## Verification is proof of control of the recovery factor

Before, "verified" was hardcoded to email: `repo.email_verified(user)`, the `email_verified` column, and a gate that raised at construction unless the model had an email column. That left a placeholder seam: a phone-recovery app declared `recovery="phone"` (PR 1) but had no way to verify the phone.

Now the repository resolves the factor: `recovery_verified(user)` reads `email_verified` when the recovery factor is email and `{factor}_verified` otherwise (`recovery=None` is never verified); `mark_recovery_verified(db, user)` writes the right column. `Principal` gains `recovery_verified` (populated by `build_principal`) alongside the kept `email_verified`. `current_user(verified=True)` now gates on `recovery_verified` and raises at construction only when `recovery is None` (an account shape with nothing to prove control of), not when email is absent. For an email-recovery app this is identical to before; for a phone app it finally works.

**Why this shape:** the contract already knows the recovery factor (`identity.recovery`), so "verified" should mean that factor is proven, not "an email is proven." `email_verified` stays the column for email apps (back-compat), and the concept generalizes above it.

---

## The proof is the same machinery, re-pointed (security core untouched)

`email_verified=True` was always backed by a real proof: the user returned a signed, one-time-use, TTL'd token delivered to the address being verified. Generalizing had to preserve that exactly, or it would be a silent downgrade to "some channel said OK."

It does. The redemption core is byte-for-byte unchanged: `verify_signed_token`, `_consume` (one-time-use), and the TTL are not touched. The only diffs in `confirm_*` are the verified read/write switching to `recovery_verified` / `mark_recovery_verified`. On the request side, the token is now looked up by, and delivered to, the recovery factor: `DeliveryIntent.recipient = repo.get(user, identity.recovery)`. This is where PR 1's deferred "recipient is still email" gap closes, for both the verify and the password-reset flows (reset also delivers to the factor). `change_email` stays email-shaped (it intrinsically proves a new email address).

---

## The verified flag is as unsettable as `email_verified` always was

`email_verified` was protected on every write path because it is a `LOGICAL_FIELDS` member. A non-email `{factor}_verified` column is not, so it had to be gated explicitly or it would be a settable-without-proof downgrade. `repo._recovery_verified_col()` is unioned into both `_gated_names` (the register allowlist) and `_contract_names` (the provisioning filter), so `{factor}_verified` is dropped on all three write paths: register (even if opted into `register_extra_fields`), `new_user_defaults` (gated at construction), and `new_user_fields` (gated via `filter_provisioning_data`). The only way to set it remains returning the delivered token.

---

## The mixin emits `{factor}_verified`; names made factor-neutral

`make_auth_identity(recovery="phone")` now emits a `phone_verified` bookkeeping column (NOT NULL, default `False`); `recovery="email"` does not double-emit (the always-present `email_verified` is reused); `recovery=None` emits no extra flag. The app still declares the factor column itself (`phone`, with its own constraints), the same as any app column.

With the behavior generalized, the names were renamed so the surface stops lying for non-email apps. The `verify_email` delivery kind is kept for email recovery (so existing `EmailSender` implementations that switch on it are unaffected) and a factor-neutral `verify_recovery` is emitted for any other factor, so a channel never gets an "email"-named verify for a phone. The service methods became `request_recovery_verification` / `confirm_recovery_verification`, and the public hook `on_after_email_verified` became `on_after_recovery_verified`. Names that are genuinely email-specific kept their names: `on_after_email_changed` and OAuth's `email_verified` (both prove an actual email, per the convention's test), and the `/verify-email` default path (user-facing config).

---

## Documentation Updates

**`docs/guides/infra/hooks.md`:**
- The hooks table row `on_after_email_verified` becomes `on_after_recovery_verified` ("recovery-factor verification confirm").

**`docs/guides/accounts/email.md`:**
- The "Hooks" prose names `on_after_recovery_verified` instead of `on_after_email_verified`.

(The API reference page renders `AuthHooks` via mkdocstrings, so the renamed field updates automatically.)

---

## Test Plan

### Automated
- [x] `uv run ruff check crudauth tests` — clean
- [x] `uv run mypy crudauth tests --config-file pyproject.toml` — clean (100 files)
- [x] `uv run pytest` — 294 passed (the pre-existing email suite unchanged, the back-compat anchor)

### Verification is proof of the recovery factor
- [x] Phone verify requires returning the delivered token: invalid/replayed token does not verify, valid token does (`test_phone_verify_requires_the_delivered_token`)
- [x] `recovery_verified` reads the right column per factor: email → `email_verified`, phone → `phone_verified`, `recovery=None` → always False (`test_recovery_verified_reads_right_column_per_factor`)
- [x] Email recovery: `recovery_verified` equals `email_verified` (`test_email_recovery_equals_email_verified`)
- [x] `current_user(verified=True)`: raises at construction for `recovery=None`; 403 unverified then 200 after verifying (`test_verified_gate_requires_recovery_factor`, `test_phone_verify_delivers_to_phone_and_gates_on_it`)

### Delivery re-pointed to the factor
- [x] Verify delivers to the phone, with the factor-neutral `verify_recovery` kind (`test_phone_verify_delivers_to_phone_and_gates_on_it`)
- [x] Password reset delivers to the phone too (`test_phone_reset_delivers_to_the_phone`)

### The flag is unsettable on every write path
- [x] `{factor}_verified` dropped from register (even opted in) and provisioning (`test_factor_verified_unsettable_via_register_and_provisioning`)
- [x] `{factor}_verified` dropped from `new_user_defaults` at construction (`test_factor_verified_unsettable_via_new_user_defaults`)

### Mixin factory
- [x] `recovery="phone"` emits `phone_verified`; `recovery="email"` does not double-emit; `recovery=None` emits no extra flag (`test_factory_*`)

---

## Dependencies

None new.

## Breaking Changes

- **`AuthHooks.on_after_email_verified` renamed to `on_after_recovery_verified`** (and the internal `run_after_email_verified` to `run_after_recovery_verified`). Public surface: an app registering `AuthHooks(on_after_email_verified=...)` must rename the kwarg. Done as a real rename, not a deprecated alias, deliberately, while the breaking-change cost is zero (pre-prod, no overriders). `on_after_email_changed` is unchanged (it proves an actual new email).
- **`EmailFlowService.request_email_verification` / `confirm_email_verification` renamed** to `request_recovery_verification` / `confirm_recovery_verification`, and `request_email_verification` / `request_password_reset` now take a `value` parameter (the recovery-factor value) instead of `email`. `EmailFlowService` is constructed by `CRUDAuth` internally, so most apps are unaffected; direct callers must update.
- **`current_user(verified=True)` semantics generalized.** It now gates on `recovery_verified` and raises at construction only for `recovery=None` (previously: required an email column). Email-recovery apps behave identically; a non-email app that previously hit the placeholder raise now works.
- **Additive (not breaking):** `UserRepository(recovery=...)` parameter and `recovery_verified`/`mark_recovery_verified` methods (defaults preserve email behavior); `Principal.recovery_verified` field (`email_verified` kept); the `verify_recovery` value added to `EmailKind` (email recovery still emits `verify_email`); `make_auth_identity` emits `{factor}_verified` only for non-email factors (the default shape is unchanged).
