### PR TITLE
EmailContext: custom email bodies without losing the built-in flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 - **Your model, your schema**: works over your existing SQLAlchemy `User` via a logical-field `column_map` - no forced renames, no second user table.
 - **Secure by default**: synchronizer-token CSRF, escalating per-IP/per-user login lockout, bcrypt with SHA-256 pre-hash (no 72-byte truncation), timing-equalized login, and trusted-proxy IP resolution.
 - **OAuth**: Google, GitHub, or a custom provider - with the `state` bound to the initiating browser to block login CSRF.
-- **Email flows**: verify / reset / change - you implement the `EmailSender` port, the package mints and verifies the signed, single-use tokens.
+- **Email flows**: verify / reset / change - you implement the `EmailSender` port (render your own HTML from `context.link`), the package mints and verifies the signed, single-use tokens.
 - **Sudo mode**: short-lived re-authentication to gate sensitive actions, stamped on the session and cleared on logout.
 - **Multi-device sessions**: list, revoke one, or "sign out everywhere", with a configurable per-user session cap.
 - **App policy in hooks**: `AuthHooks` for welcome email, trial grant, audit logging - fired uniformly across every auth path.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ Or with uv:
 uv add crudauth
 ```
 
+## AI agents (library skill)
+
+crudauth ships a [library skill](https://library-skills.io) embedded in the package, so AI coding
+agents follow its actual conventions and gotchas (account shapes, gates, recovery, custom email
+bodies, production wiring) in sync with the version you installed. After adding crudauth, install it
+into your project:
+
+```bash
+uvx library-skills            # scans deps, links bundled skills (re-run to keep them in sync on upgrade)
+uvx library-skills --claude   # for Claude Code (.claude/skills)
+```
+
 ## Quickstart
 
 Sessions are the default - no `transports=` needed. You get cookie auth, CSRF,

--- a/crudauth/.agents/skills/crudauth/SKILL.md
+++ b/crudauth/.agents/skills/crudauth/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: crudauth
+description: >
+  Use when building or modifying authentication in a FastAPI app with crudauth (the `crudauth` PyPI
+  package) — covers `CRUDAuth`, the `AuthUserMixin` / `make_auth_identity` user model, `IdentityConfig`,
+  `current_user(...)` gates, session + bearer transports, OAuth (Google/GitHub), email verification /
+  password reset / change, custom email bodies (`EmailSender` / `EmailContext` / `DeliveryChannel`),
+  registration allowlists and provisioning, sudo mode, and account shapes (email, username-only, phone
+  recovery). Activate when the code imports `crudauth`, defines a `CRUDAuth(...)`, a `current_user`
+  dependency, an `AuthUserMixin` model, or an `EmailSender`, or when the user asks to add login /
+  signup / sessions / JWT / OAuth / email verification to a FastAPI app, even without naming the library.
+license: MIT
+metadata:
+  author: benav-labs
+  package: crudauth
+---
+
+# crudauth
+
+crudauth is transport-agnostic authentication for FastAPI over **your own** SQLAlchemy 2.0 user model.
+One object is the composition root:
+
+- **`CRUDAuth(...)`** — configure session, model, secret, transports, email, OAuth once. Mount
+  `auth.router` to get the endpoints; call `auth.current_user(...)` to gate routes.
+- Every transport (cookie session, bearer JWT, OAuth) resolves to one **`Principal`**, so your
+  authorization code never depends on how the request authenticated.
+
+`CRUDAuth` (capitalized) is the object you build; `crudauth` lowercase is the package/import. This
+skill covers `crudauth >= 0.4`.
+
+**The highest-value content is the [Security invariants](#security-invariants-do-not-break-these) and
+[Gotchas](#gotchas) sections — read them before writing code.** Most crudauth mistakes are security
+regressions (gating on the wrong flag, leaking account existence, making a privileged field settable),
+not API misuse.
+
+---
+
+## Canonical setup
+
+The minimal viable app. Start here, then add transports / email / OAuth as needed.
+
+```python
+# models.py — crudauth adds its columns to a model you own
+from sqlalchemy.orm import Mapped, mapped_column
+from crudauth.models import AuthUserMixin
+from myapp.db import Base
+
+class User(Base, AuthUserMixin):
+    __tablename__ = "users"
+    full_name: Mapped[str | None] = mapped_column(default=None)   # your columns ride alongside
+```
+
+```python
+# main.py
+import os
+from fastapi import FastAPI, Depends
+from crudauth import CRUDAuth, Principal
+from myapp.db import get_session          # async dependency yielding AsyncSession
+from myapp.models import User
+
+auth = CRUDAuth(session=get_session, user_model=User, SECRET_KEY=os.environ["SECRET_KEY"])
+
+app = FastAPI()
+app.include_router(auth.router)            # /register, /login, /logout, /me (+ CSRF, login lockout)
+
+@app.get("/dashboard")
+async def dashboard(user: Principal = Depends(auth.current_user())):
+    return {"id": user.user_id}
+```
+
+`AuthUserMixin` is the default account shape (email + username login, email recovery). `SECRET_KEY`
+comes from the environment, never a literal. crudauth never opens DB connections itself — it borrows
+`get_session`.
+
+---
+
+## Choosing the account shape
+
+The **model is the source of truth**. `CRUDAuth` reads its columns and validates them against
+`IdentityConfig` at construction (fail-closed). Pick the shape, then declare it in both places.
+
+| Want | Model | `identity=` |
+|---|---|---|
+| Email + username login, email recovery (default) | `AuthUserMixin` | (omit) |
+| Username-only, no email, no recovery | `make_auth_identity(identifiers=["username"], recovery=None, oauth=False)` | `IdentityConfig(login=["username"], recovery=None)` + a `register_schema` without email |
+| Phone recovery (verify/reset over SMS) | `make_auth_identity(identifiers=["username"], recovery="phone", oauth=False)` + your own unique `phone` column | `IdentityConfig(login=["username"], recovery="phone")` + a `DeliveryChannel` |
+| Adopt an existing `users` table | your existing model | pass `column_map={"id": "account_id", "hashed_password": "pw_hash", ...}` |
+
+Full details, the emitted columns, and `column_map` mechanics: `references/identity.md`.
+
+---
+
+## Choosing the gate
+
+`auth.current_user(...)` returns a FastAPI dependency. Combine options freely:
+
+| Need | Gate |
+|---|---|
+| Any authenticated user | `current_user()` |
+| Proven recovery factor (email/phone verified) | `current_user(verified=True)` |
+| Admin | `current_user(superuser=True)` |
+| Bearer scope | `current_user(scopes=["reports:read"])` |
+| Custom rule | `current_user(check=lambda p: p.user.org_id == 1)` (denies only on `False`) |
+| Allow anonymous | `current_user(optional=True)` (returns `None` instead of 401) |
+| One credential kind only | `current_user(transport="session")` / `"bearer"` |
+
+The handler receives a `Principal` (`user_id`, `scopes`, `transport`, `user`, `is_superuser`,
+`email_verified`, `recovery_verified`, `metadata`). Full reference: `references/gates.md`.
+
+---
+
+## Transports
+
+```python
+from crudauth import SessionTransport, BearerTransport
+auth = CRUDAuth(..., transports=[SessionTransport(), BearerTransport(access_ttl=900, refresh="cookie")])
+```
+
+`SessionTransport` → `/login` `/logout` (cookies + CSRF, for browsers). `BearerTransport` → `/token`
+`/refresh` (JWT, for API/mobile/CLI; `refresh="body"` returns the refresh token in JSON; scopes via
+`default_scopes` / `grantable_scopes`). With both, the first credential **present** wins and both
+resolve to the same `Principal`, so a route's gates don't change. CSRF is automatic on the session
+transport and irrelevant to bearer. See `references/transports.md`.
+
+---
+
+## Email, recovery, and custom bodies
+
+```python
+from crudauth import CRUDAuth, EmailConfig, EmailSender
+
+class MySender(EmailSender):
+    async def send(self, *, to, subject, body, kind, context):
+        # plain: deliver `body` (crudauth's text) as-is.
+        # branded HTML: build it from context.link — the assembled URL, token embedded.
+        await tasks.enqueue(send_email, to=to, subject=subject, html=body)
+
+auth = CRUDAuth(..., email=EmailConfig(sender=MySender(), frontend_url="https://app.example.com"))
+```
+
+`email=` mounts verify / reset / change. `send` receives an **`EmailContext`** (`kind`, `link`,
+`recipient`, `expires_in`) — crudauth-owned render data only, so you build your own HTML from
+`context.link` without parsing it out of `body`. For SMS/push, or per-user copy, implement a
+`DeliveryChannel` (`deliver(intent, db)`, gets the `db` handle and user row) and pass `channels=[...]`.
+Full flows, endpoints, the `kind` values, and the security rules: `references/email.md`.
+
+---
+
+## Registration & provisioning
+
+`/register` is a **strict allowlist**. A column a client sends is dropped unless listed in
+`register_extra_fields={"display_name"}`. For server-set columns (a default tier, a derived name),
+use `new_user_defaults={...}` (constants) or `new_user_fields=callback` (derived; runs on `/register`
+**and** OAuth signup). Privileged fields (`is_superuser`, `email_verified`, `token_version`, oauth ids,
+the PK) are never settable through any of these.
+
+---
+
+## OAuth
+
+```python
+from crudauth import OAuthCredentials, SessionTransport
+auth = CRUDAuth(..., transports=[SessionTransport()], redirect_base_url="https://app.example.com",
+                oauth={"google": OAuthCredentials(client_id=..., client_secret=...)})
+```
+
+Adds `/oauth/{provider}/authorize` + `/oauth/{provider}/callback`. Needs a `SessionTransport`,
+`redirect_base_url`, and a `{provider}_id` column (`AuthUserMixin` has the built-ins). Auto-links to an
+existing account **only on a provider-verified email**. See `references/oauth.md`.
+
+---
+
+## Production
+
+In-memory backends aren't shared across workers (crudauth warns at startup). Use Redis and wire the
+lifespan:
+
+```python
+from crudauth.ratelimit import redis_rate_limiter
+auth = CRUDAuth(..., transports=[SessionTransport(backend="redis", redis_url=REDIS_URL)],
+                rate_limiter=redis_rate_limiter(REDIS_URL))
+
+@asynccontextmanager
+async def lifespan(app):
+    await auth.initialize(); yield; await auth.shutdown()
+```
+
+Serve over HTTPS (session cookies are `secure` by default); set `trusted_proxy_hops=N` behind a load
+balancer. See `references/production.md` for storage, lockout tuning, and sudo mode.
+
+---
+
+## Security invariants (do not break these)
+
+These are the load-bearing rules. Breaking one is a vulnerability, not a style nit.
+
+1. **Gate "verified" with `current_user(verified=True)`, never `principal.email_verified`.** The flag
+   is `False` on a non-email account (username-only, phone), so `check=lambda p: p.email_verified`
+   silently always-denies those apps. `verified=True` reads the contract's recovery factor.
+2. **Never make email/recovery request endpoints reveal whether an account exists.** They return a
+   uniform response by design (non-enumeration). A "helpful" 404 for an unknown email is a regression.
+3. **`/register` must not set privileged columns.** `is_superuser`, `email_verified`,
+   `{factor}_verified`, `token_version`, oauth ids, and the PK stay gated even if sent or listed in
+   `register_extra_fields`. Server-set values go through `new_user_defaults` / `new_user_fields`.
+4. **`EmailContext` carries no user-controlled data and no bare token.** Don't put `username`/`email`
+   into email HTML via the sender — that's an XSS surface crudauth deliberately avoids. Personalize in
+   a `DeliveryChannel` (it owns escaping). The token reaches the sender only embedded in `context.link`.
+5. **OAuth links to an existing account only on a verified provider email.** Don't relax this; it's the
+   account-takeover defense.
+
+---
+
+## Gotchas
+
+1. **`EmailSender.send` takes `context` (since 0.4).** Signature is
+   `send(self, *, to, subject, body, kind, context)`. An old 4-arg `send` raises `TypeError`. Render
+   HTML from `context.link`; `body` stays the plain-text fallback.
+2. **`current_user(verified=True)` raises at construction when `recovery=None`.** A no-recovery shape
+   has nothing to prove control of, so the gate is a config error, not a silent deny.
+3. **`check=` denies only on `False`.** Returning `False` is a 403; `None` or any other value does
+   **not** deny. To deny with a custom status/message, raise from inside `check`.
+4. **Reach the user via `Principal` / the repo, not ad-hoc attributes.** crudauth speaks logical field
+   names mapped through `column_map`; a hardcoded `user.email` breaks a remapped or email-less model.
+5. **A password reset evicts the user's other sessions** (bumps `token_version`, revoking bearer
+   tokens). Intended attacker eviction, not a bug.
+6. **Bearer scopes are clamped to `grantable_scopes`.** A token can't self-grant beyond the ceiling,
+   re-checked at `/refresh`.
+7. **A session cookie may never be `SameSite=None`** — rejected at construction. Bearer's refresh
+   cookie may.
+8. **`recovery="phone"` emits a `phone_verified` column**, but you declare the `phone` column yourself
+   (unique). The factory emits the `{factor}_verified` bookkeeping flag.
+9. **Username collisions are public (422 "already taken"); email collisions are not** (uniform 202).
+   Username is a public namespace by design; don't "fix" the asymmetry.
+10. **`SECRET_KEY` rotation invalidates every session and token.** Treat it as a managed secret.
+11. **`new_user_fields` runs on OAuth signup too**, fed a server-built context (never the request
+    body). Use it for columns both signup paths must set.
+12. **OAuth is unavailable on an `oauth=False` model** (no `{provider}_id` columns).
+
+---
+
+## When to drill into references
+
+Load on demand:
+
+- `references/identity.md` — account shapes, `make_auth_identity`, `IdentityConfig`, the emitted
+  columns, `column_map`, the recovery factor and `{factor}_verified`.
+- `references/gates.md` — every `current_user(...)` option, the `Principal` shape, authorization patterns.
+- `references/transports.md` — session vs bearer, `/token` `/refresh`, scopes, CSRF, multiple transports.
+- `references/email.md` — `EmailConfig`, `EmailSender` + `EmailContext`, `DeliveryChannel` / `DeliveryIntent`,
+  the message kinds, verify/reset/change endpoints, non-enumeration.
+- `references/oauth.md` — providers, `OAuthCredentials`, account linking, `/set-password`, custom providers.
+- `references/production.md` — Redis storage, lifespan, rate limiting & lockout, sudo mode, proxies, secrets.

--- a/crudauth/.agents/skills/crudauth/references/email.md
+++ b/crudauth/.agents/skills/crudauth/references/email.md
@@ -1,0 +1,100 @@
+# Email, recovery, and custom bodies
+
+crudauth owns the recovery token (mint, one-time-use, TTL'd redemption); you own delivery and copy.
+There are two layers: the **`EmailSender`** port (the built-in email channel's transport) for plain or
+branded email, and the **`DeliveryChannel`** port for any medium (SMS, push) or per-user copy.
+
+## EmailConfig + EmailSender
+
+```python
+from crudauth import CRUDAuth, EmailConfig, EmailSender
+
+class MySender(EmailSender):
+    async def send(self, *, to, subject, body, kind, context):
+        await tasks.enqueue(send_email, to=to, subject=subject, html=body)
+
+auth = CRUDAuth(..., email=EmailConfig(
+    sender=MySender(),
+    frontend_url="https://app.example.com",   # links point here: {frontend_url}{path}?token=...
+    # verify_path / reset_path / change_path and *_ttl_hours are configurable
+))
+```
+
+`email=` mounts the recovery routes. crudauth composes `subject` + a plain-text `body` (the link
+included) and calls `send`. **Prefer enqueueing over blocking on SMTP** — registration sends are
+best-effort (failure logged), but verify/reset/change can surface a raised send as a 5xx.
+
+### EmailContext — render your own HTML (since 0.4)
+
+`send`'s `context` is an `EmailContext` with crudauth-owned render data:
+
+```python
+@dataclass(frozen=True)
+class EmailContext:
+    kind: EmailKind        # verify_email | verify_recovery | reset_password | change_email | existing_account
+    link: str | None       # assembled URL, token embedded; None for existing_account
+    recipient: str
+    expires_in: int        # seconds; 0 when link is None
+```
+
+```python
+async def send(self, *, to, subject, body, kind, context):
+    html = render(f"emails/{kind}.html", link=context.link, expires_in=context.expires_in)
+    await tasks.enqueue(send_email, to=to, subject=subject, html=html)
+```
+
+- `context.link` is the **same** assembled URL that's inside `body` (one source). Build a real
+  `<a href>` from it; don't regex `body`.
+- `context` carries **no user-controlled fields and no bare token** — putting `username`/`email` into
+  HTML is an XSS surface crudauth refuses to be. The token reaches you only embedded in `link`.
+- `body` stays the plain-text fallback: a sender that ignores `context` produces the pre-0.4 email.
+
+## DeliveryChannel — other media, or per-user copy
+
+```python
+from crudauth import DeliveryChannel, DeliveryIntent
+
+class SmsChannel(DeliveryChannel):
+    async def deliver(self, intent: DeliveryIntent, db) -> None:
+        if intent.token is None:
+            return  # existing_account notice has no action
+        msg = f"Verify: https://app/recover?token={intent.token}" if intent.kind == "verify_recovery" \
+              else f"Reset: https://app/recover?token={intent.token}"
+        await sms_client.send(to=intent.recipient, body=msg)
+
+auth = CRUDAuth(..., channels=[SmsChannel()])
+```
+
+`DeliveryIntent`: `kind`, `token` (the bare token, for building your own URL), `user`
+(`repo.to_dict`, contract fields only — load app columns off `db`), `recipient`, `expires_in`.
+
+- A channel may use `db` (a live session) to load extra columns and personalize. This is the
+  home for `Hi Alice`, because the channel owns its escaping.
+- crudauth fires every configured channel **best-effort** and swallows per-channel failures, so raise
+  freely on a provider error: it never surfaces to the caller (no enumeration oracle) and never stops
+  the next channel.
+- For a non-email recovery factor, verification arrives as `kind="verify_recovery"` (not the
+  email-named `verify_email`). `reset_password` / `change_email` / `existing_account` are factor-neutral
+  in name.
+
+## Endpoints and flows
+
+Mounted by `email=` (and/or `channels=` when there's a recovery factor):
+
+| Endpoint | Body | Notes |
+|---|---|---|
+| `POST /email/verify-request` | `{"<factor>": ...}` | factor-shaped (email app: `email`; phone app: `phone`) |
+| `POST /email/verify-confirm` | `{"token": ...}` | marks the factor verified |
+| `POST /password/reset-request` | `{"<factor>": ...}` | |
+| `POST /password/reset-confirm` | `{"token", "new_password"}` | evicts the user's other sessions |
+| `POST /email/change-request` | `{"new_email", "password"}` | authenticated; mounts only when the model has an `email` column |
+| `POST /email/change-confirm` | `{"token"}` | |
+
+## Security rules
+
+- **Request endpoints are non-enumerable.** They return a uniform response whether or not the account
+  exists (and skip already-verified). Don't change them to reveal existence.
+- **`current_user(verified=True)` gates on the recovery factor**, not `email_verified`.
+- A successful **password reset bumps `token_version`**, revoking the user's outstanding bearer tokens
+  and other sessions.
+- The `{factor}_verified` flag is set only by redeeming the delivered token; it is unsettable at signup.

--- a/crudauth/.agents/skills/crudauth/references/gates.md
+++ b/crudauth/.agents/skills/crudauth/references/gates.md
@@ -1,0 +1,85 @@
+# Gates: current_user and the Principal
+
+`auth.current_user(...)` builds a FastAPI dependency that authenticates the request once (cached on
+`request.state`, so stacking gates and a `KeyBy.USER` rate limit does one authentication) and then
+authorizes it. The handler receives a `Principal`.
+
+## `current_user(...)` options
+
+```python
+auth.current_user(
+    verified=False,     # require the recovery factor proven controlled
+    superuser=False,    # require is_superuser
+    scopes=None,        # list[str]; require these bearer scopes
+    check=None,         # Callable[[Principal], Any], sync or async; denies only when it returns False
+    optional=False,     # return None instead of 401 when unauthenticated
+    transport=None,     # "session" | "bearer" | list; restrict to credential kinds
+)
+```
+
+All are combinable; all run on the same shared `Principal`, per call.
+
+```python
+@app.get("/me")
+async def me(u: Principal = Depends(auth.current_user())): ...
+
+@app.get("/billing")
+async def billing(u: Principal = Depends(auth.current_user(verified=True))): ...
+
+@app.delete("/admin/{id}")
+async def rm(id: int, u: Principal = Depends(auth.current_user(superuser=True))): ...
+
+@app.get("/reports")
+async def reports(u: Principal = Depends(auth.current_user(scopes=["reports:read"]))): ...
+
+@app.get("/org")
+async def org(u: Principal = Depends(auth.current_user(check=lambda p: p.user.org_id == 1))): ...
+
+@app.get("/maybe")
+async def maybe(u: Principal | None = Depends(auth.current_user(optional=True))):
+    return {"anon": u is None}
+```
+
+## The `Principal`
+
+```python
+from crudauth import Principal
+
+@dataclass
+class Principal:
+    user_id: Any                 # the PK, coerced to the column's python type
+    scopes: tuple[str, ...]
+    transport: str               # "session" | "bearer" | provider name
+    user: Any                    # the loaded ORM row (your model)
+    is_superuser: bool
+    email_verified: bool         # email-specific; see warning below
+    recovery_verified: bool      # the contract's recovery factor is proven
+    metadata: dict[str, Any]
+```
+
+- **Gate on `recovery_verified` / `current_user(verified=True)`, not `email_verified`.** `email_verified`
+  is `False` on a non-email account, so a custom `check=lambda p: p.email_verified` always-denies a
+  username-only or phone app. `email_verified` exists for the `/me` payload and for email apps where it
+  equals `recovery_verified`.
+- `user` is your ORM row; read columns off it, but prefer the logical contract when writing code that
+  must survive a `column_map` rename (a hardcoded `user.email` breaks a remapped/email-less model).
+
+## Semantics
+
+- **`check=` denies only on `False`.** Returning `False` → 403; `None` or any other non-`False` value
+  does not deny. To deny with a custom status/message, raise your own exception from inside `check`.
+  (Since 0.2.0; earlier the return was ignored entirely.)
+- **`verified=True` raises at construction when the contract has `recovery=None`** — nothing to prove
+  control of, so it's a config error, surfaced early, not a silent always-deny.
+- **`transport=` narrows to a credential kind.** A `transport="bearer"` route rejects a cookie session
+  even if one is present; pass a list to accept a subset.
+- **`optional=True` still hard-fails a present-but-invalid credential.** A tampered token or a CSRF
+  failure raises even under `optional`, because that's an attack signal, not "anonymous".
+
+## Patterns
+
+- **Role/ownership:** put the rule in `check=`; keep it a pure predicate on the `Principal`.
+- **App policy (welcome email, trial grant):** don't inline it in a route; register an `AuthHooks`
+  callback (`on_after_register`, `on_after_login`, ...) so it fires uniformly across every path.
+- **Per-user rate limit:** `auth.rate_limit(action, key=KeyBy.USER)` resolves the user via the same
+  cached authentication, so it composes with `current_user` without a second lookup.

--- a/crudauth/.agents/skills/crudauth/references/identity.md
+++ b/crudauth/.agents/skills/crudauth/references/identity.md
@@ -1,0 +1,106 @@
+# Identity: account shapes, the model contract, and column_map
+
+crudauth reads an account's *shape* from your model and validates it against `IdentityConfig` at
+`CRUDAuth` construction. The model is the single source of truth; the config only declares intent a
+schema can't carry (login order, recovery factor). A mismatch fails closed at startup.
+
+## `make_auth_identity` and `AuthUserMixin`
+
+```python
+from crudauth import make_auth_identity
+from crudauth.models import AuthUserMixin   # == make_auth_identity()  (the default shape)
+
+make_auth_identity(
+    identifiers=("email", "username"),   # which columns can be a login identifier
+    recovery="email",                    # the recovery factor: "email", another field name, or None
+    oauth=True,                          # emit oauth-linkage columns (google_id, github_id, ...)
+)
+```
+
+It returns a declarative mixin you inherit:
+
+```python
+class User(Base, make_auth_identity(identifiers=["username"], recovery="phone", oauth=False)):
+    __tablename__ = "users"
+    phone: Mapped[str | None] = mapped_column(String(32), unique=True, default=None)
+```
+
+### Columns the factory emits
+
+`AuthUserMixin` (the default) emits: `id`, `email`, `username`, `hashed_password`, `is_active`,
+`is_superuser`, `email_verified`, `token_version`, the oauth columns (`oauth_provider`, `google_id`,
+`github_id`, `oauth_created_at`, `oauth_updated_at`), and `created_at` / `updated_at`.
+
+- An identifier that isn't `email` drops the `email` column when `recovery` isn't email either.
+- `oauth=False` drops the oauth columns.
+- A non-email recovery factor emits a `{factor}_verified` bookkeeping flag (e.g. `phone_verified`), but
+  you declare the factor column itself (e.g. a unique `phone`). `email_verified` is always emitted.
+
+## `IdentityConfig`
+
+```python
+from crudauth import IdentityConfig
+IdentityConfig(login=["email", "username"], recovery="email")   # the default
+```
+
+- `login`: the fields `/login` accepts, in resolution order. Each must be a **single-column unique**
+  column on the model (a composite unique constraint does not count). Login matches against these
+  fields; there is no `@`-in-the-string heuristic.
+- `recovery`: the factor that verification and password reset operate on (`"email"`, another field
+  name, or `None`). Pass it to `CRUDAuth(identity=IdentityConfig(...))`.
+
+Construction raises if a `login` field isn't a unique column, if `recovery` isn't unique, if OAuth is
+enabled without `email` in `login`, or if `email=` config is set without an `email` column.
+
+## The three shapes, end to end
+
+```python
+# 1. Email + username (default): just inherit AuthUserMixin; omit identity=.
+
+# 2. Username-only (no email, no recovery)
+class User(Base, make_auth_identity(identifiers=["username"], recovery=None, oauth=False)):
+    __tablename__ = "users"
+auth = CRUDAuth(..., identity=IdentityConfig(login=["username"], recovery=None),
+                register_schema=UsernameOnlyRegister)   # default /register body requires email
+# Consequence: no /password/reset-request (no recovery), and current_user(verified=True) raises.
+
+# 3. Phone recovery
+class User(Base, make_auth_identity(identifiers=["username"], recovery="phone", oauth=False)):
+    __tablename__ = "users"
+    phone: Mapped[str | None] = mapped_column(String(32), unique=True, default=None)
+auth = CRUDAuth(..., identity=IdentityConfig(login=["username"], recovery="phone"),
+                channels=[SmsChannel()], register_schema=Register, register_extra_fields={"phone"})
+```
+
+## `column_map` — adopt an existing table
+
+crudauth speaks *logical* field names; `column_map` maps each to your actual column. List only the
+ones that differ:
+
+```python
+auth = CRUDAuth(..., column_map={
+    "id": "account_id",
+    "email": "email_address",
+    "hashed_password": "pw_hash",
+    "is_superuser": "is_admin",
+})
+```
+
+Logical fields (the `column_map`-able contract): `id`, `email`, `username`, `hashed_password`,
+`is_active`, `is_superuser`, `email_verified`, `token_version`, `oauth_provider`, `google_id`,
+`github_id`, `oauth_created_at`, `oauth_updated_at`. (`created_at` / `updated_at` are emitted by the
+mixin but are not part of the contract, so they aren't remapped.)
+
+Bookkeeping columns degrade gracefully if absent: `is_active` → treated active, `email_verified` →
+`False`, `token_version` → `0` (revocation/eviction becomes a no-op). Add the ones whose feature you
+want. The registration allowlist gates the **mapped** column too (`is_admin` is as ungated as
+`is_superuser`).
+
+## Gotchas
+
+- Account shape lives on the model, not re-declared in `IdentityConfig`. The config declares intent
+  (order, factor); the columns come from the model.
+- A `login` field must be single-column unique. Composite-only uniqueness raises at construction.
+- `recovery=None` means no recovery endpoints mount and `current_user(verified=True)` raises.
+- The `{factor}_verified` flag is set only by token redemption; it's gated on every write path
+  (register allowlist, `new_user_defaults`, `new_user_fields`).

--- a/crudauth/.agents/skills/crudauth/references/oauth.md
+++ b/crudauth/.agents/skills/crudauth/references/oauth.md
@@ -1,0 +1,74 @@
+# OAuth
+
+crudauth runs the authorization-code flow, links the result to a user, and establishes a session on
+the callback. It requires a `SessionTransport`, a public `redirect_base_url`, and a `{provider}_id`
+column on the model.
+
+## Setup
+
+```python
+from crudauth import CRUDAuth, OAuthCredentials, SessionTransport
+
+auth = CRUDAuth(
+    ..., transports=[SessionTransport()],
+    redirect_base_url="https://app.example.com",
+    oauth={
+        "google": OAuthCredentials(client_id=..., client_secret=...),
+        "github": OAuthCredentials(client_id=..., client_secret=...),
+    },
+)
+```
+
+`OAuthCredentials(client_id, client_secret, scopes=None)`. Built-in providers: `"google"`, `"github"`
+(they self-register on import). `AuthUserMixin` includes `google_id` / `github_id`; a custom shape
+needs `oauth=True`.
+
+## Endpoints and the button
+
+Each provider adds `GET /oauth/{provider}/authorize` and `GET /oauth/{provider}/callback`. Register
+`{redirect_base_url}/oauth/{provider}/callback` as the provider's redirect URI. The frontend is one
+link:
+
+```html
+<a href="/oauth/google/authorize?redirect_to=/dashboard">Sign in with Google</a>
+```
+
+`redirect_to` is where the callback sends the browser after login — **same-origin relative paths
+only** (open-redirect hardened).
+
+## The callback: link or create
+
+1. The flow is CSRF-hardened: `state` is bound to the initiating browser via a short-lived cookie the
+   callback must match, so a captured/forged callback can't complete someone else's login.
+2. Then crudauth finds or creates the user, in order:
+   - **provider id hit** → that user (returning login).
+   - **verified-email match** → links the provider to the existing account (`{provider}_id` set), so
+     the user can then sign in by password or provider. **Linking requires `info.email_verified`** — an
+     unverified provider email matching an existing account is refused ("sign in with your existing
+     method to link"), the account-takeover defense.
+   - **otherwise** → a new user, created with `email_verified` taken from the provider (a Google user
+     usually arrives verified), an unusable password, and a unique username derived from the profile.
+
+## Provisioning OAuth users
+
+`new_user_fields` / `new_user_defaults` run on the OAuth create path too. The callback's
+`NewUserContext` has `email`, `username`, `source="oauth"`, the live `db`, and the provider profile, plus
+`ctx.suggested_name` (provider display name, email local-part fallback):
+
+```python
+auth = CRUDAuth(..., new_user_defaults={"tier": "free"},
+                new_user_fields=lambda ctx: {"display_name": ctx.suggested_name})
+```
+
+## Password for an OAuth-only account
+
+An OAuth-created user has no usable password. `POST /set-password` lets an authenticated OAuth-only
+account set a first password; alternatively the password-reset flow doubles as "set a password". After
+that, both doors work.
+
+## Custom provider
+
+Implement the `AbstractOAuthProvider` port (`provider.py`: pass the three endpoints + scopes +
+`provider_name`, implement `process_user_info(raw) -> OAuthUserInfo`, set `email_verified` honestly),
+register it with `OAuthProviderFactory.register_provider("name", YourProvider)`, then pass its
+credentials in `oauth={"name": OAuthCredentials(...)}` like a built-in.

--- a/crudauth/.agents/skills/crudauth/references/production.md
+++ b/crudauth/.agents/skills/crudauth/references/production.md
@@ -1,0 +1,90 @@
+# Production: storage, lifespan, rate limiting, sudo
+
+The dev defaults run in one process: state lives in memory, the limiter is in-process, cookies work
+over plain HTTP. Going to production is four changes; the auth config and the API don't change, only
+*where state lives* and the operational wiring.
+
+## 1. Move state to Redis
+
+crudauth keeps server-side state (sessions, CSRF, lockout counters, single-use email/OAuth tokens) in
+a pluggable store. In memory it isn't shared across workers/pods, which silently weakens lockout,
+sessions, and one-time-token atomicity. Point both stores at Redis:
+
+```python
+from crudauth import CRUDAuth, SessionTransport
+from crudauth.ratelimit import redis_rate_limiter
+
+REDIS_URL = os.environ["REDIS_URL"]
+auth = CRUDAuth(
+    ..., transports=[SessionTransport(backend="redis", redis_url=REDIS_URL)],
+    rate_limiter=redis_rate_limiter(REDIS_URL),
+)
+```
+
+crudauth logs a startup warning whenever an in-memory backend is active. Pass
+`warn_on_memory_backend=False` only if you deliberately run a single worker.
+
+## 2. Wire the lifespan
+
+Redis backends open connections on startup. `initialize()` / `shutdown()` are required for Redis,
+no-ops for in-memory:
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+
+@asynccontextmanager
+async def lifespan(app):
+    await auth.initialize()
+    yield
+    await auth.shutdown()
+
+app = FastAPI(lifespan=lifespan)
+app.include_router(auth.router)
+```
+
+## 3. Secrets and cookies
+
+- `SECRET_KEY` from the environment, never a literal. Rotating it invalidates every session and token.
+- Session cookies are `secure=True` by default — serve over HTTPS. Don't set `CookieConfig(secure=False)`
+  outside local dev. A session cookie may never be `SameSite=None`.
+
+## 4. Behind a proxy
+
+The socket peer is your load balancer, so IP-based throttles would see one client. Tell crudauth how
+many trusted proxies sit in front so it reads the real client IP from `X-Forwarded-For`:
+
+```python
+auth = CRUDAuth(..., trusted_proxy_hops=1)   # default 0 ignores the header (correct when nothing is in front)
+```
+
+## Rate limiting & lockout
+
+- The same escalating login-lockout policy is shared by `/login` and `/token`, keyed identically, so
+  neither endpoint sidesteps the other's failure counter. It re-arms its round TTL atomically.
+- The limiter is a dumb counter port (`rate_limiter=`). Don't construct a backend inside a transport;
+  pass it on `CRUDAuth`. Auth-adjacent endpoints carry a `rate_limit()` dependency or a service-level
+  guard; per-target-email throttles fail silently (a 429 there would re-open the enumeration oracle).
+- A custom backend implements the `RateLimiterBackend` port (the atomic counter surface) and goes in
+  `rate_limiter=`.
+
+## Sudo mode
+
+For destructive actions, require fresh re-authentication:
+
+```python
+from crudauth import SudoConfig
+auth = CRUDAuth(..., sudo=SudoConfig())
+
+@app.post("/account/delete")
+async def delete_account(_: Principal = Depends(auth.require_sudo())):
+    ...
+```
+
+Sudo is short-lived, stamped on the session, has its own lockout, and fires an `on_after_sudo` hook.
+
+## Custom storage backend
+
+Implement the storage port (serialize Pydantic models under `{prefix}{id}` with per-key TTL, plus the
+atomic `set_if_absent` / `get_and_delete` primitives the one-time-token flows need). The built-ins are
+in-memory and Redis.

--- a/crudauth/.agents/skills/crudauth/references/transports.md
+++ b/crudauth/.agents/skills/crudauth/references/transports.md
@@ -1,0 +1,67 @@
+# Transports: session, bearer, and running both
+
+A transport is an authentication channel. Each implements the same port and resolves to the same
+`Principal`, so your routes don't change when you add or narrow transports. Pass instances in
+`transports=[...]`; the default is `[SessionTransport()]`.
+
+## SessionTransport (browsers)
+
+```python
+from crudauth import SessionTransport, CookieConfig
+SessionTransport(cookies=CookieConfig(secure=True, samesite="lax"), backend="memory")
+```
+
+Adds `/login` (form-encoded `username` + `password`; `username` accepts any configured login field),
+`/logout`, and the server-side session record. Mutating requests must echo the CSRF token from the
+session cookie. `backend="redis"` (with `redis_url=`) moves sessions, CSRF, and the one-time-token /
+OAuth-state stores to Redis.
+
+- Cookies are `secure=True` by default — serve over HTTPS. A session cookie may **never** be
+  `SameSite=None` (rejected at construction).
+
+## BearerTransport (API / mobile / CLI)
+
+```python
+from crudauth import BearerTransport
+BearerTransport(
+    access_ttl=900,             # access-token lifetime, seconds (default 900)
+    refresh_ttl_days=30,
+    refresh="cookie",           # "cookie" (httpOnly) or "body" (returned in JSON)
+    default_scopes=["me:read"],
+    grantable_scopes=["me:read", "reports:read", "reports:write"],
+    refresh_cookie_path=None,   # e.g. "/refresh" to keep the cookie off every request
+)
+```
+
+Adds `POST /token` (form-encoded login → `{"access_token": ..., "token_type": "bearer"}`, plus
+`refresh_token` in the body when `refresh="body"`) and `POST /refresh`. Send the access token as
+`Authorization: Bearer <token>`.
+
+- `/refresh` with the cookie strategy rides the cookie automatically; with `refresh="body"` it reads a
+  JSON `{"refresh_token": "..."}` (cookie is checked first, then that field).
+- **Scopes are clamped to `grantable_scopes`** at login and re-clamped at `/refresh`, so a token can't
+  self-grant beyond the ceiling, and tightening the ceiling drops a removed scope from tokens minted
+  off existing refresh tokens.
+- **Revocation:** JWTs are stateless; a `token_version` epoch on the user invalidates every token
+  issued before a password reset in one step.
+
+## Both at once
+
+```python
+auth = CRUDAuth(..., transports=[SessionTransport(), BearerTransport()])
+```
+
+- **First credential present wins**, in list order. List the one you want to win first.
+- A transport returns nothing when its credential is **absent** (try the next); it **raises** for a
+  credential present-but-invalid (a tampered token, a failed CSRF check), even under `optional=True`.
+- Both yield the same `Principal`, so `current_user()` accepts either. Narrow a route with
+  `current_user(transport="bearer")` / `"session"` / `["session", "bearer"]`.
+- **CSRF is a session-transport property only** — enforced on cookie mutations, irrelevant to bearer.
+  Your API paths never deal with CSRF; your browser paths are protected automatically.
+
+## Custom transport
+
+Implement the `Transport` port from `crudauth.core` (one `authenticate(request, ctx)` method that
+returns `ctx.build_principal(...)` or `None`), optionally `contributes_routes()`, and pass an instance
+in `transports=[...]`. Build the `Principal` via `ctx.build_principal(...)`, never construct it
+directly. Resolve the user with `ctx.resolve_user(user_id)` (cached per request).

--- a/crudauth/__init__.py
+++ b/crudauth/__init__.py
@@ -24,6 +24,7 @@ from .email import (
     DeliveryKind,
     EmailChannel,
     EmailConfig,
+    EmailContext,
     EmailSender,
 )
 from .exceptions import (
@@ -58,6 +59,7 @@ __all__ = [
     "OAuthCredentials",
     "EmailConfig",
     "EmailSender",
+    "EmailContext",
     "DeliveryChannel",
     "DeliveryIntent",
     "DeliveryKind",

--- a/crudauth/email/__init__.py
+++ b/crudauth/email/__init__.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from .channel import DeliveryChannel, DeliveryIntent, DeliveryKind, EmailChannel
 from .config import EmailConfig
-from .sender import EmailSender
+from .sender import EmailContext, EmailSender
 from .service import EmailFlowService
 
 __all__ = [
     "EmailSender",
+    "EmailContext",
     "EmailConfig",
     "EmailFlowService",
     "DeliveryChannel",

--- a/crudauth/email/channel.py
+++ b/crudauth/email/channel.py
@@ -22,6 +22,7 @@ from .constants import (
     SUBJECT_VERIFY,
     EmailKind,
 )
+from .sender import EmailContext
 
 if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -132,11 +133,24 @@ class EmailChannel(DeliveryChannel):
                     f"account - sign in or reset your password at {cfg.frontend_url}."
                 ),
                 kind="existing_account",
+                context=EmailContext(
+                    kind="existing_account", link=None, recipient=intent.recipient, expires_in=0
+                ),
             )
             return
         subject, path_attr, prefix = _EMAIL_SPECS[intent.kind]
         assert intent.token is not None
         link = cfg.link(getattr(cfg, path_attr), intent.token)
         await cfg.sender.send(
-            to=intent.recipient, subject=subject, body=f"{prefix} {link}", kind=intent.kind
+            to=intent.recipient,
+            subject=subject,
+            body=f"{prefix} {link}",
+            kind=intent.kind,
+            # context.link is the SAME assembled URL as in body (one source), never the bare token.
+            context=EmailContext(
+                kind=intent.kind,
+                link=link,
+                recipient=intent.recipient,
+                expires_in=intent.expires_in,
+            ),
         )

--- a/crudauth/email/sender.py
+++ b/crudauth/email/sender.py
@@ -3,38 +3,94 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 from .constants import EMAIL_KINDS, EmailKind
 
-__all__ = ["EmailSender", "EmailKind", "EMAIL_KINDS"]
+__all__ = ["EmailSender", "EmailContext", "EmailKind", "EMAIL_KINDS"]
+
+
+@dataclass(frozen=True)
+class EmailContext:
+    """crudauth-owned render data handed to [EmailSender.send][crudauth.email.sender.EmailSender.send].
+
+    Everything a sender needs to render its own HTML around crudauth's recovery
+    flow, and *nothing else*. Specifically it carries the assembled ``link`` (the
+    signed token is already embedded in the URL, which is what gets emailed), not
+    the bare token, and it carries **no user-controlled fields** (no ``username``,
+    no ``email``). That is deliberate: a sender drops these values into HTML, so
+    crudauth keeps anything injectable out of reach and is never the XSS vector.
+
+    For per-user personalization (``Hi Alice``), write a
+    [DeliveryChannel][crudauth.email.channel.DeliveryChannel] instead: it receives
+    the ``db`` handle and the user row, and owns its own escaping.
+
+    Attributes:
+        kind: Which message this is - one of :data:`EMAIL_KINDS`.
+        link: The assembled, ready-to-click URL with the token embedded, or
+            ``None`` for ``existing_account`` (a notice with no action).
+        recipient: The destination address crudauth resolved.
+        expires_in: Token lifetime in seconds, or ``0`` when ``link`` is ``None``.
+
+    Example:
+        ```python
+        # inside EmailSender.send, render your own HTML from the context:
+        html = f'<a href="{context.link}">Verify your email</a>'
+        ```
+    """
+
+    kind: EmailKind
+    link: str | None
+    recipient: str
+    expires_in: int
 
 
 class EmailSender(ABC):
     """Adapter crudauth calls to deliver a message.
 
-    crudauth builds the subject and body (including the signed-token link) and
-    hands them to you; you decide how to deliver (SMTP, SES, a task queue...).
-    ``kind`` lets you pick the template; a bad ``kind`` is a type error.
+    crudauth composes the subject and a plain-text ``body`` (with the signed-token
+    link in it) and hands them to you; you decide how to deliver (SMTP, SES, a task
+    queue...). For a plain sender, deliver ``body`` as-is. To send your own HTML,
+    read [context][crudauth.email.sender.EmailContext] - ``context.link`` is the
+    assembled URL, so you can build a real ``<a href>`` button or branded template
+    without regexing the link out of ``body``.
+
+    ``context`` carries crudauth-owned render data only (link, kind, expiry,
+    recipient), never the bare token and never user-controlled fields. For per-user
+    personalization, write a [DeliveryChannel][crudauth.email.channel.DeliveryChannel]
+    (it has ``db`` and owns escaping) rather than reaching for user data here.
 
     Example:
         ```python
         class MyEmailSender(EmailSender):
-            async def send(self, *, to, subject, body, kind):
-                await my_task_queue.enqueue(send_email, to=to, subject=subject, html=body)
+            async def send(self, *, to, subject, body, kind, context):
+                # plain: deliver crudauth's text as-is.
+                # html:  build your own from context.link.
+                html = render(f"{kind}.html", link=context.link) if context.link else body
+                await my_task_queue.enqueue(send_email, to=to, subject=subject, html=html)
         ```
     """
 
     @abstractmethod
-    async def send(self, *, to: str, subject: str, body: str, kind: EmailKind) -> None:
+    async def send(
+        self, *, to: str, subject: str, body: str, kind: EmailKind, context: EmailContext
+    ) -> None:
         """Deliver one message.
 
         Args:
             to: Recipient address.
             subject: Message subject crudauth composed.
-            body: Message body, including any signed-token link.
+            body: Plain-text message body crudauth composed, including the
+                signed-token link. Deliver it as-is for a plain sender, or ignore
+                it and render your own from ``context``.
             kind: Which message this is - one of :data:`EMAIL_KINDS`. Use it to
                 select the template (``existing_account`` is a security notice,
                 not a welcome).
+            context: crudauth-owned render data
+                ([EmailContext][crudauth.email.sender.EmailContext]): the assembled
+                ``link``, ``kind``, ``recipient``, and ``expires_in``. Read
+                ``context.link`` to build HTML. It carries no bare token and no
+                user-controlled fields by design.
 
         Note:
             Prefer to **enqueue** (hand off to a task queue) rather than block on

--- a/docs/api/email.md
+++ b/docs/api/email.md
@@ -7,4 +7,6 @@ and verifies the single-use tokens through `EmailFlowService`.
 
 ::: crudauth.email.EmailSender
 
+::: crudauth.email.EmailContext
+
 ::: crudauth.email.EmailFlowService

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,32 @@ breaking changes; those are called out explicitly.
 
 ___
 
+## 0.4.0 - 2026-06-21
+
+Custom email bodies. `EmailSender.send` now receives an `EmailContext`, so you render your own
+branded HTML for the verify / reset / change emails instead of delivering crudauth's plain text.
+
+#### Added
+- **`EmailContext` on `EmailSender.send`:** the sender now gets the assembled `link` (the token
+  embedded in the URL), `kind`, `recipient`, and `expires_in`, so it can build a real HTML template
+  without parsing the link out of `body`. The context carries crudauth-owned render data only -
+  never the bare token, never user-controlled fields - so a sender that drops it into HTML can't be
+  an XSS or credential-leak vector. `context.link` is the same assembled URL as in `body` (one
+  source). Per-user personalization (`Hi Alice`) stays a `DeliveryChannel` concern (it has the `db`
+  handle and owns escaping).
+- **Bundled Agent Skill** (`crudauth/.agents/skills/crudauth/`): crudauth now ships a
+  [library skill](https://agentskills.io), so AI coding agents that support the format get crudauth's
+  conventions and gotchas (account shapes, gates, recovery, custom email bodies, production wiring) on
+  demand when working in a project that depends on it. Installed automatically with the package.
+
+#### Breaking changes
+- **`EmailSender.send` gains a required `context` parameter.** Add it to your `send` signature
+  (`async def send(self, *, to, subject, body, kind, context)`); behavior is unchanged because
+  `body` is still the pre-rendered plain-text fallback, so a sender that ignores `context` produces
+  the same email as before.
+
+___
+
 ## 0.3.0 - 2026-06-20
 
 Account shapes. CRUDAuth's identity and recovery are now read from your model instead of assumed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,10 +18,11 @@ branded HTML for the verify / reset / change emails instead of delivering crudau
   an XSS or credential-leak vector. `context.link` is the same assembled URL as in `body` (one
   source). Per-user personalization (`Hi Alice`) stays a `DeliveryChannel` concern (it has the `db`
   handle and owns escaping).
-- **Bundled Agent Skill** (`crudauth/.agents/skills/crudauth/`): crudauth now ships a
-  [library skill](https://agentskills.io), so AI coding agents that support the format get crudauth's
-  conventions and gotchas (account shapes, gates, recovery, custom email bodies, production wiring) on
-  demand when working in a project that depends on it. Installed automatically with the package.
+- **Bundled library skill** (`crudauth/.agents/skills/crudauth/`): crudauth now ships an embedded
+  [library skill](https://library-skills.io), so AI coding agents follow crudauth's actual conventions
+  and gotchas (account shapes, gates, recovery, custom email bodies, production wiring) in sync with the
+  installed version. It travels in the wheel; install it into your project's agent with
+  `uvx library-skills` (add `--claude` for Claude Code).
 
 #### Breaking changes
 - **`EmailSender.send` gains a required `context` parameter.** Add it to your `send` signature

--- a/docs/cookbook/email-password.md
+++ b/docs/cookbook/email-password.md
@@ -84,8 +84,8 @@ over blocking the request on SMTP:
 from crudauth import EmailConfig, EmailSender
 
 class MySender(EmailSender):
-    async def send(self, *, to, subject, body, kind):
-        # crudauth already built the subject and body (with the link). You deliver it.
+    async def send(self, *, to, subject, body, kind, context):
+        # plain: deliver crudauth's text body as-is.
         await tasks.enqueue(send_email, to=to, subject=subject, html=body)
 
 auth = CRUDAuth(
@@ -98,6 +98,12 @@ Passing `email=` is what mounts the verify, reset, and change-email routes. `fro
 where the links point: your frontend reads the token out of the URL and posts it back to the
 matching confirm endpoint. The `kind` argument tells your sender which message it's delivering
 (verification, reset, and so on) so you can pick a template.
+
+Want a branded HTML email instead of crudauth's plain text? Read `context`: `context.link` is the
+assembled URL, so you build your own template (`render(f"{kind}.html", link=context.link)`) without
+parsing the link out of `body`. The [email guide](../guides/accounts/email.md#sending-your-own-html)
+covers it; `context` deliberately carries no user data, so per-user copy is a
+[delivery channel](../guides/accounts/email.md#delivery-channels) job.
 
 ## 4. Register, log in, and protect a route
 

--- a/docs/guides/accounts/email.md
+++ b/docs/guides/accounts/email.md
@@ -14,8 +14,9 @@ they enable the six routes below.
 from crudauth import CRUDAuth, EmailConfig, EmailSender
 
 class MySender(EmailSender):
-    async def send(self, *, to, subject, body, kind):
-        # crudauth already built the subject and body (with the link). You deliver it.
+    async def send(self, *, to, subject, body, kind, context):
+        # plain: deliver crudauth's text as-is. branded HTML: build your own
+        # from context.link (the assembled URL), no need to parse it out of body.
         await tasks.enqueue(send_email, to=to, subject=subject, html=body)
 
 auth = CRUDAuth(
@@ -28,6 +29,24 @@ app.include_router(auth.router)   # adds the verify / reset / change routes
 Prefer enqueueing onto a task queue over blocking on SMTP here: registration sends are
 best-effort (a failure is logged), but the verify/reset/change flows surface a raised send as
 a 5xx.
+
+### Sending your own HTML
+
+`body` is crudauth's plain-text default. To send a branded template, read `context`
+([`EmailContext`](../../api/email.md)): `context.link` is the assembled, ready-to-click URL, so
+you build a real button without regexing the link out of `body`, and `context.kind` /
+`context.expires_in` round out the copy.
+
+```python
+async def send(self, *, to, subject, body, kind, context):
+    html = render(f"emails/{kind}.html", link=context.link, expires_in=context.expires_in)
+    await tasks.enqueue(send_email, to=to, subject=subject, html=html)
+```
+
+`context` carries crudauth-owned data only (link, kind, recipient, expiry), never the bare token
+and never user-controlled fields, so the sender can't be an injection vector. For per-user copy
+(`Hi Alice`), write a [delivery channel](#delivery-channels) instead: it gets the `db` handle and
+the user row, and owns its own escaping.
 
 <p align="center">
   <img src="../../assets/diagrams/email-flow-light.png#only-light" alt="Three-step email flow: a request endpoint always returns 200, CRUDAuth signs a single-use token and your EmailSender delivers the link, and the confirm endpoint verifies and consumes the token once" width="100%">
@@ -82,6 +101,10 @@ don't leak which accounts are registered. Tokens are single-use and time-limited
 Email is the built-in delivery channel, but the token isn't email-specific. CRUDAuth owns the
 token (mint, one-time-use, redemption); a `DeliveryChannel` owns the medium and the copy. Pass
 `channels=` to route the same reset/verify token over SMS, WhatsApp, push, or several at once:
+
+If you only want a branded HTML *email* (not a new medium), you don't need a channel: read
+`context.link` in your `EmailSender` ([Sending your own HTML](#sending-your-own-html) above). Reach
+for a channel when you need a different medium, or per-user copy that loads data off the `db`.
 
 ```python
 from crudauth import CRUDAuth, DeliveryChannel, DeliveryIntent, EmailConfig

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@
 - **Your model, your schema**: works over your existing SQLAlchemy `User` via a logical-field `column_map` - no forced renames, no second user table.
 - **Secure by default**: synchronizer-token CSRF, escalating per-IP/per-user login lockout, bcrypt with SHA-256 pre-hash (no 72-byte truncation), timing-equalized login, and trusted-proxy IP resolution.
 - **OAuth**: Google, GitHub, or a custom provider - with the `state` bound to the initiating browser to block login CSRF.
-- **Email flows**: verify / reset / change - you implement the `EmailSender` port, the package mints and verifies the signed, single-use tokens.
+- **Email flows**: verify / reset / change - you implement the `EmailSender` port (render your own HTML from `context.link`), the package mints and verifies the signed, single-use tokens.
 - **Sudo mode**: short-lived re-authentication to gate sensitive actions, stamped on the session and cleared on logout.
 - **Multi-device sessions**: list, revoke one, or "sign out everywhere", with a configurable per-user session cap.
 - **App policy in hooks**: `AuthHooks` for welcome email, trial grant, audit logging - fired uniformly across every auth path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,11 @@
 
 For OAuth, Redis, and device parsing, install the extras: `pip install "crudauth[all]"`.
 
+CRUDAuth ships a [library skill](https://library-skills.io) embedded in the package, so AI coding
+agents follow its actual conventions in sync with the installed version. Install it into your project
+with `uvx library-skills` (add `--claude` for Claude Code); re-run it after upgrading to keep the
+skill current.
+
 ### 2. Mount the router
 
 Sessions are the default - no `transports=` needed. You get cookie auth, CSRF,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crudauth"
-version = "0.3.0"
+version = "0.4.0"
 description = "Batteries-included, transport-agnostic authentication for FastAPI."
 readme = "README.md"
 license = "MIT"

--- a/tests/email/test_channels.py
+++ b/tests/email/test_channels.py
@@ -41,8 +41,10 @@ class CapturingSender(EmailSender):
     def __init__(self) -> None:
         self.sent: list[dict] = []
 
-    async def send(self, *, to, subject, body, kind) -> None:
-        self.sent.append({"to": to, "subject": subject, "body": body, "kind": kind})
+    async def send(self, *, to, subject, body, kind, context) -> None:
+        self.sent.append(
+            {"to": to, "subject": subject, "body": body, "kind": kind, "context": context}
+        )
 
 
 async def _make_user(repo, sessionmaker, email="real@x.com") -> None:

--- a/tests/email/test_email_context.py
+++ b/tests/email/test_email_context.py
@@ -1,0 +1,132 @@
+"""EmailContext: the sender-facing render data.
+
+The security shape of this feature, asserted directly: the context carries the
+assembled link (token embedded in the URL), never a bare token and never any
+user-controlled field, so a sender that drops context values into HTML can't be
+the XSS or credential-leak vector. `context.link` is the SAME URL that's in
+`body` (one source, can't diverge), and a sender that ignores context produces
+today's exact email (the back-compat anchor)."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from crudauth import AuthHooks, DeliveryIntent, EmailConfig, EmailContext, EmailSender
+from crudauth.email.channel import EmailChannel
+from crudauth.email.service import EmailFlowService
+from crudauth.repository import UserRepository
+from crudauth.utils import get_password_hash
+
+SECRET = "test-secret-key-0123456789-0123456789"
+FRONTEND = "https://app.example.com"
+
+
+class RecordingSender(EmailSender):
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def send(self, *, to, subject, body, kind, context) -> None:
+        self.calls.append(
+            {"to": to, "subject": subject, "body": body, "kind": kind, "context": context}
+        )
+
+
+def _channel(sender: EmailSender) -> EmailChannel:
+    return EmailChannel(EmailConfig(sender=sender, frontend_url=FRONTEND))
+
+
+# --- the security regression catch: context exposes only crudauth render data ---
+
+
+def test_context_exposes_only_crudauth_owned_fields() -> None:
+    # If someone later adds `username`/`email`/`token` to EmailContext for
+    # convenience, this fails - that's the point. User data is a DeliveryChannel
+    # concern; the bare token stays on DeliveryIntent.
+    names = {f.name for f in fields(EmailContext)}
+    assert names == {"kind", "link", "recipient", "expires_in"}
+    assert "token" not in names
+    assert not any(n in names for n in ("user", "username", "email"))
+
+
+async def test_link_carries_the_token_so_the_context_need_not() -> None:
+    # The credential reaches the sender only as part of the URL (which is what
+    # gets emailed), never as a standalone field it could mishandle.
+    sender = RecordingSender()
+    await _channel(sender).deliver(
+        DeliveryIntent(
+            kind="verify_email", token="tok123", user={}, recipient="a@x.com", expires_in=3600
+        ),
+        db=None,
+    )
+    ctx = sender.calls[-1]["context"]
+    assert isinstance(ctx, EmailContext)
+    assert ctx.link is not None and "token=tok123" in ctx.link
+    assert not hasattr(ctx, "token")
+
+
+# --- single source: context.link is the same URL as in body ---
+
+
+async def test_context_link_equals_body_link_and_body_unchanged() -> None:
+    sender = RecordingSender()
+    await _channel(sender).deliver(
+        DeliveryIntent(
+            kind="verify_email", token="tok123", user={}, recipient="a@x.com", expires_in=3600
+        ),
+        db=None,
+    )
+    call = sender.calls[-1]
+    ctx = call["context"]
+    assert ctx.link is not None and ctx.link in call["body"]
+    # back-compat anchor: body is byte-identical to what shipped before context.
+    assert call["body"] == f"Verify your email: {ctx.link}"
+    assert ctx.recipient == "a@x.com" and ctx.expires_in == 3600
+
+
+async def test_existing_account_context_has_no_link() -> None:
+    sender = RecordingSender()
+    await _channel(sender).deliver(
+        DeliveryIntent(
+            kind="existing_account", token=None, user={}, recipient="a@x.com", expires_in=0
+        ),
+        db=None,
+    )
+    ctx = sender.calls[-1]["context"]
+    assert ctx.kind == "existing_account" and ctx.link is None and ctx.expires_in == 0
+
+
+# --- non-enumeration unchanged: an absent account never reaches the sender ---
+
+
+async def test_absent_account_never_invokes_the_sender(sessionmaker, UserModel) -> None:
+    sender = RecordingSender()
+    svc = EmailFlowService(
+        repo=UserRepository(UserModel),
+        secret_key=SECRET,
+        hooks=AuthHooks(),
+        config=EmailConfig(sender=sender, frontend_url=FRONTEND),
+    )
+    async with sessionmaker() as db:
+        await svc.request_password_reset(db, "ghost@x.com")
+    assert sender.calls == []
+
+
+async def test_real_flow_passes_context_with_matching_link(sessionmaker, UserModel) -> None:
+    repo = UserRepository(UserModel)
+    async with sessionmaker() as db:
+        await repo.create(
+            db,
+            {"email": "real@x.com", "username": "real", "hashed_password": get_password_hash("pw")},
+        )
+    sender = RecordingSender()
+    svc = EmailFlowService(
+        repo=repo,
+        secret_key=SECRET,
+        hooks=AuthHooks(),
+        config=EmailConfig(sender=sender, frontend_url=FRONTEND),
+    )
+    async with sessionmaker() as db:
+        await svc.request_password_reset(db, "real@x.com")
+    call = sender.calls[-1]
+    assert call["kind"] == "reset_password"
+    assert call["context"].link is not None and call["context"].link in call["body"]

--- a/tests/email/test_flows.py
+++ b/tests/email/test_flows.py
@@ -16,8 +16,10 @@ class CapturingSender(EmailSender):
     def __init__(self) -> None:
         self.sent: list[dict] = []
 
-    async def send(self, *, to, subject, body, kind):
-        self.sent.append({"to": to, "subject": subject, "body": body, "kind": kind})
+    async def send(self, *, to, subject, body, kind, context):
+        self.sent.append(
+            {"to": to, "subject": subject, "body": body, "kind": kind, "context": context}
+        )
 
     def token_for(self, kind):
         for msg in reversed(self.sent):
@@ -165,7 +167,7 @@ async def test_reset_request_idempotent_for_unknown_email(ctx) -> None:
 
 
 class _BoomSender(EmailSender):
-    async def send(self, *, to, subject, body, kind) -> None:
+    async def send(self, *, to, subject, body, kind, context) -> None:
         raise RuntimeError("SMTP down")
 
 
@@ -191,7 +193,7 @@ async def test_reset_request_uniform_when_send_fails(sessionmaker, UserModel) ->
 
 
 class _FailingSender(EmailSender):
-    async def send(self, *, to, subject, body, kind) -> None:
+    async def send(self, *, to, subject, body, kind, context) -> None:
         raise RuntimeError("smtp down")
 
 

--- a/tests/email/test_ratelimit.py
+++ b/tests/email/test_ratelimit.py
@@ -15,6 +15,7 @@ from crudauth import (
     CookieConfig,
     CRUDAuth,
     EmailConfig,
+    EmailContext,
     EmailSender,
     SessionTransport,
 )
@@ -28,7 +29,9 @@ class Capture(EmailSender):
     def __init__(self) -> None:
         self.sent: list[dict] = []
 
-    async def send(self, *, to: str, subject: str, body: str, kind: str) -> None:
+    async def send(
+        self, *, to: str, subject: str, body: str, kind: str, context: EmailContext
+    ) -> None:
         self.sent.append({"to": to, "kind": kind})
 
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -33,7 +33,7 @@ SECRET = "test-secret-key-0123456789-0123456789"
 
 class _Sender(EmailSender):
     async def send(
-        self, *, to, subject, body, kind
+        self, *, to, subject, body, kind, context
     ) -> None:  # pragma: no cover - never sent in these tests
         pass
 

--- a/tests/test_recovery_verification.py
+++ b/tests/test_recovery_verification.py
@@ -305,5 +305,7 @@ async def test_phone_request_body_is_phone_shaped_not_email() -> None:
 async def test_email_less_phone_app_mounts_no_change_email() -> None:
     # change-email proves a real address; an email-less phone app doesn't mount it.
     async with _phone_app() as (auth, client, _maker, _channel):
-        r = await client.post("/email/change-request", json={"new_email": "a@x.com", "password": "pw"})
+        r = await client.post(
+            "/email/change-request", json={"new_email": "a@x.com", "password": "pw"}
+        )
         assert r.status_code == 404

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -16,6 +16,7 @@ from crudauth import (
     CRUDAuth,
     CookieConfig,
     EmailConfig,
+    EmailContext,
     EmailSender,
     OAuthCredentials,
     SessionTransport,
@@ -377,7 +378,9 @@ class _Capture(EmailSender):
     def __init__(self) -> None:
         self.sent: list[dict] = []
 
-    async def send(self, *, to: str, subject: str, body: str, kind: str) -> None:
+    async def send(
+        self, *, to: str, subject: str, body: str, kind: str, context: EmailContext
+    ) -> None:
         self.sent.append({"to": to, "kind": kind})
 
 

--- a/tests/transports/test_bearer.py
+++ b/tests/transports/test_bearer.py
@@ -13,6 +13,7 @@ from crudauth import (
     CookieConfig,
     CRUDAuth,
     EmailConfig,
+    EmailContext,
     EmailSender,
     Principal,
     SessionTransport,
@@ -221,7 +222,9 @@ class _Capture(EmailSender):
     def __init__(self) -> None:
         self.sent: list[dict] = []
 
-    async def send(self, *, to: str, subject: str, body: str, kind: str) -> None:
+    async def send(
+        self, *, to: str, subject: str, body: str, kind: str, context: EmailContext
+    ) -> None:
         self.sent.append({"body": body, "kind": kind})
 
     def token_for(self, kind: str) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "crudauth"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
# EmailContext: custom email bodies without losing the built-in flow

The built-in `EmailChannel` hands `EmailSender.send` a finished plain-text `body`, so an app that
wants a branded HTML email had to regex crudauth's link out of that string, or abandon the email
path entirely and write a whole `DeliveryChannel`. This branch gives `send` a structured
`EmailContext` (the assembled link, kind, recipient, expiry) so a sender renders its own HTML
directly, while keeping `body` as the unchanged fallback. The context deliberately carries no bare
token and no user-controlled fields, so crudauth can't become a credential-leak or XSS vector. It
is a one-line breaking change to `EmailSender.send`. The branch also bundles a crudauth library skill
so AI coding agents working in a downstream project get the library's conventions and gotchas.

---

## Custom email bodies via `EmailContext`

Before, the only render data a sender received was `kind`. The signed-token link existed only as a
substring of `body` (`"Verify your email: https://app/...?token=..."`), so building a real
`<a href>` button meant string-parsing crudauth's copy. That is the actual pain this fixes: not "no
HTML," but "the link is trapped in a rendered string."

`EmailContext` is a frozen dataclass of crudauth-owned render data, passed to `send` alongside the
existing `to` / `subject` / `body` / `kind`:

```python
@dataclass(frozen=True)
class EmailContext:
    kind: EmailKind        # verify_email | verify_recovery | reset_password | change_email | existing_account
    link: str | None       # assembled URL, token embedded; None for existing_account (no action)
    recipient: str
    expires_in: int        # seconds; 0 when link is None
```

A sender that wants branding reads `context.link`; a sender that doesn't keeps delivering `body`.
`EmailChannel` builds the context from the *same* `EmailConfig.link(path, token)` it already uses for
`body`, so `context.link` and the URL inside `body` are one source and can never diverge.
`existing_account` (a notice with no action) passes `link=None, expires_in=0`.

---

## The context carries crudauth-owned data only

This is the load-bearing decision. The moment a sender receives structured fields instead of a
finished string, what it receives becomes a security boundary, because the sender drops those values
into HTML. So `EmailContext` carries the assembled link (the token is already inside the URL, which
is what gets emailed) and never the bare token, and it carries no user-controlled fields, no
`username`, no `email`. crudauth therefore never hands the sender anything injectable, and can't be
the XSS or credential-mishandling vector for content it never exposed.

Per-user personalization (`Hi Alice`) stays on the `DeliveryChannel` path, which already receives the
`db` handle and the user row and owns its own escaping. The bare token likewise stays on
`DeliveryIntent` for custom channels that build their own URL. So the split is by layer: branding on
the `EmailSender` (crudauth-owned data, no escaping burden), personalization on a `DeliveryChannel`
(app-owned data, app-owned escaping).

**Why a dataclass and not just more `send` args:** a single frozen object keeps the boundary visible
and auditable in one place, so a future "let's add `username` for convenience" is a one-line change
that a test and a convention grep both catch, rather than an easy slip.

---

## Signature-only break, with `body` retained as the fallback

`EmailSender.send` gains a required `context` parameter. There is no non-breaking way to pass a new
keyword to a method that does not declare it, and signature introspection is fragile magic this
codebase rejects, so this is an honest, documented break, the same class as the 0.3.0 renames. The
migration is one line: add the parameter and ignore it.

```python
# before
async def send(self, *, to, subject, body, kind): ...
# after, behavior identical
async def send(self, *, to, subject, body, kind, context): ...
```

Crucially the break is signature-only, not behavioral. `body` is still crudauth's pre-rendered
plain text, so a sender that ignores `context` produces the exact email it produced before. Every
existing test that asserts on `body` still passes, which is the proof.

---

## Bundled library skill

crudauth had no machine-readable guidance, so an agent working in a downstream project guessed at the
conventions — and the easy guesses are the dangerous ones (gating on `email_verified`, leaking account
existence, making a privileged field settable at signup). This branch bundles a
[library skill](https://library-skills.io) at `crudauth/.agents/skills/crudauth/`: a concise `SKILL.md`
(canonical setup, account-shape and gate tables, a Security-invariants block, numbered gotchas) plus
six on-demand `references/` files (identity, gates, transports, email, oauth, production). It ships in
the wheel automatically (`uv_build` includes `.agents`), so it travels with the package and stays in
sync with the installed version; a project installs it into its agent with `uvx library-skills`.

Every factual claim in the skill was validated against the source. The frontmatter is spec-valid
(`name` matches the directory, description within 1024 chars).

---

## Documentation Updates

**`docs/guides/accounts/email.md`:**
- New "Sending your own HTML" section: read `context.link` to build a template, with the explicit
  note that `context` carries no user data so personalization is a delivery-channel concern.
- The "Delivery channels" section now cross-refers back, so a reader doesn't write a whole channel
  just to brand an email.

**`docs/cookbook/email-password.md`:** the sender example gains `context`, with a pointer to the
custom-HTML path.

**`docs/api/email.md`:** renders `EmailContext` (`::: crudauth.email.EmailContext`).

**`README.md`, `docs/index.md`:** the email feature bullet notes "render your own HTML from
`context.link`".

**`docs/changelog.md`:** `0.4.0` entry (the `EmailContext` change + the bundled skill).

**`crudauth/.agents/skills/crudauth/`:** the new library skill (`SKILL.md` + six references).

---

## Test Plan

### Automated
- [x] `uv run ruff check crudauth tests` — clean
- [x] `uv run mypy crudauth tests --config-file pyproject.toml` — clean (101 files)
- [x] `uv run pytest` — 303 passing
- [x] `uv run --group docs zensical build` — no issues
- [x] `uv build --wheel` — the skill ships under `crudauth/.agents/...` in the wheel

### The security boundary (`tests/email/test_email_context.py`)
- [x] `EmailContext` field set is exactly `{kind, link, recipient, expires_in}` — fails if `username`/`token` is ever added (`test_context_exposes_only_crudauth_owned_fields`)
- [x] The token reaches the sender only embedded in `link`, never as a standalone field (`test_link_carries_the_token_so_the_context_need_not`)

### Single source + back-compat
- [x] `context.link` equals the URL in `body`, and `body` is byte-identical to pre-context (`test_context_link_equals_body_link_and_body_unchanged`)
- [x] The existing email verify/reset/change suite passes unchanged (senders that ignore `context` behave as before)

### Behavior
- [x] `existing_account` passes `link=None`, `expires_in=0` (`test_existing_account_context_has_no_link`)
- [x] Real service flow passes a context whose link matches the body (`test_real_flow_passes_context_with_matching_link`)
- [x] Non-enumeration intact: an absent account never invokes the sender (`test_absent_account_never_invokes_the_sender`)

---

## Dependencies

None new. (`sharp` for diagram regen is dev-only and unrelated to this branch.)

## Breaking Changes

- **`EmailSender.send` gains a required `context` parameter.** Every `EmailSender` implementation
  must add `context` to its `send` signature, or calls raise `TypeError: unexpected keyword
  argument 'context'`. The migration is one line (add the param); behavior is unchanged because
  `body` is still the pre-rendered fallback. This is the only break; no symbols were removed and no
  existing behavior changed.
