### PR TITLE
Account & device management: session/CSRF routes + in-session password change

### DIFF
--- a/crudauth/__init__.py
+++ b/crudauth/__init__.py
@@ -38,7 +38,7 @@ from .exceptions import (
     UnauthorizedException,
     UnprocessableEntityException,
 )
-from .crud_auth import CRUDAuth
+from .crud_auth import CRUDAuth, SessionInfo
 from .hooks import AuthHooks, HookContext
 from .identity import IdentityConfig
 from .models.mixin import AuthUserMixin, make_auth_identity
@@ -53,6 +53,7 @@ __version__ = version("crudauth")
 __all__ = [
     "__version__",
     "CRUDAuth",
+    "SessionInfo",
     "Principal",
     "SessionTransport",
     "BearerTransport",

--- a/crudauth/crud_auth.py
+++ b/crudauth/crud_auth.py
@@ -12,6 +12,7 @@ async def me(user: Principal = Depends(auth.current_user())):
 
 import inspect
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Callable, Sequence
 
 from fastapi import APIRouter, Depends, Request, Response
@@ -35,10 +36,11 @@ from .email.service import EmailFlowService
 from .exceptions import (
     BadRequestException,
     ForbiddenException,
+    NotFoundException,
     RateLimitException,
     UnauthorizedException,
 )
-from .hooks import AuthHooks
+from .hooks import AuthHooks, HookContext
 from .identity import IdentityConfig
 from .oauth import OAuthAccountService, OAuthProviderFactory
 from .oauth.router import build_oauth_router
@@ -57,8 +59,9 @@ from .storage import get_session_storage
 from .sudo import SudoConfig, SudoManager
 from .storage.constants import BACKEND_MEMORY
 from .transports.bearer.transport import BearerTransport
+from .transports.session.constants import REMEMBER_ME_META_KEY
 from .transports.session.transport import SessionTransport
-from .utils import get_client_ip, get_password_hash, is_unusable_password
+from .utils import get_client_ip, get_password_hash, is_unusable_password, verify_password
 
 if TYPE_CHECKING:  # pragma: no cover
     from .ratelimit import RateLimiterBackend
@@ -71,6 +74,26 @@ __all__ = ["CRUDAuth"]
 
 class _SetPasswordIn(BaseModel):
     new_password: Annotated[str, Field(min_length=MIN_PASSWORD_LENGTH)]
+
+
+class _ChangePasswordIn(BaseModel):
+    current_password: str
+    new_password: Annotated[str, Field(min_length=MIN_PASSWORD_LENGTH)]
+
+
+class SessionInfo(BaseModel):
+    """One active session, as returned by ``GET /sessions``.
+
+    ``device`` is the parsed user-agent info (browser/os/device flags), empty when
+    UA parsing isn't available; timestamps serialize to ISO-8601.
+    """
+
+    session_id: str
+    device: dict[str, Any] = Field(default_factory=dict)
+    ip: str = ""
+    created_at: datetime
+    last_activity: datetime
+    current: bool = False
 
 
 class CRUDAuth:
@@ -766,7 +789,139 @@ class CRUDAuth:
             )
             return {"detail": "Password set."}
 
+        @router.post(
+            "/change-password",
+            dependencies=[Depends(self.rate_limit("change_password", key=KeyBy.USER))],
+        )
+        async def change_password(
+            body: _ChangePasswordIn,
+            request: Request,
+            principal: Annotated[Principal, Depends(self.current_user())],
+            db: Annotated[Any, Depends(self.session)],
+        ):
+            """Change the password for an authenticated account, verifying the current one.
+
+            Note:
+                Re-auth is the *current password*: the active session/token proves
+                presence, the current password proves intent. Allowed over any
+                transport - CSRF is automatic on the session path, and bearer has
+                no CSRF surface. An account with no usable password gets a 400
+                (use ``/set-password`` to create the first one).
+
+            Note:
+                A password change is a compromise response: it bumps
+                ``token_version`` (evicting bearer tokens; a no-op without the
+                column) and revokes the user's OTHER sessions, keeping the current
+                one. Same eviction shape as a password reset.
+            """
+            user = principal.user
+            current_hash = self.repo.get(user, "hashed_password", "")
+            if is_unusable_password(current_hash):
+                raise BadRequestException(
+                    "Account has no password; use /set-password to create one."
+                )
+            if not verify_password(body.current_password, current_hash):
+                raise UnauthorizedException("Current password is incorrect.")
+            await self.repo.update(
+                db, user, {"hashed_password": get_password_hash(body.new_password)}
+            )
+            await self.repo.increment_token_version(db, user)
+            if self.sessions is not None:
+                await self.sessions.revoke_all(
+                    principal.user_id, exclude=principal.metadata.get("session_id")
+                )
+            await self.hooks.run_after_password_changed(
+                self.repo.to_dict(user),
+                db=db,
+                context=HookContext(transport=principal.transport, request=request),
+            )
+            return {"detail": "Password changed."}
+
+        if self._session_transport is not None and self._session_transport.management_routes:
+            self._add_session_management_routes(router)
+
         return router
+
+    def _add_session_management_routes(self, router: APIRouter) -> None:
+        """Mount the opt-in session/CSRF management routes (``SessionTransport(management_routes=True)``)."""
+        sessions = self.sessions
+        assert sessions is not None
+        session_user = self.current_user(transport="session")
+
+        @router.post(
+            "/logout-all",
+            dependencies=[Depends(self.rate_limit("logout_all", key=KeyBy.USER))],
+        )
+        async def logout_all(
+            response: Response,
+            principal: Annotated[Principal, Depends(session_user)],
+            keep_current: bool = False,
+        ):
+            """Sign out of all sessions. ``keep_current=True`` keeps the calling session."""
+            current_sid = principal.metadata.get("session_id")
+            revoked = await sessions.revoke_all(
+                principal.user_id, exclude=current_sid if keep_current else None
+            )
+            if not keep_current:
+                sessions.clear_session_cookies(response)
+            return {"detail": "Signed out of all sessions.", "revoked": revoked}
+
+        @router.get("/sessions", response_model=list[SessionInfo])
+        async def list_sessions(principal: Annotated[Principal, Depends(session_user)]):
+            """List the user's active sessions. ``[]`` if the backend can't index by user."""
+            return await sessions.list_for_user(
+                principal.user_id, current_session_id=principal.metadata.get("session_id")
+            )
+
+        @router.delete("/sessions/{session_id}")
+        async def revoke_session(
+            session_id: str,
+            response: Response,
+            principal: Annotated[Principal, Depends(session_user)],
+        ):
+            """Revoke one session by id (ownership-checked; 404 also covers 'not yours')."""
+            ok = await sessions.revoke(session_id, owner_id=principal.user_id)
+            if not ok:
+                raise NotFoundException("Session not found.")
+            if session_id == principal.metadata.get("session_id"):
+                sessions.clear_session_cookies(response)
+            return {"detail": "Session revoked."}
+
+        @router.post(
+            "/csrf/refresh",
+            dependencies=[Depends(self.rate_limit("csrf_refresh", key=KeyBy.IP))],
+        )
+        async def csrf_refresh(request: Request, response: Response):
+            """Re-mint the CSRF cookie when it's lost but the session is still valid.
+
+            Note:
+                Deliberately NOT behind ``current_user`` - requiring a valid CSRF
+                header to refresh CSRF would defeat the recovery purpose. It
+                resolves the session cookie directly. An attacker can *trigger*
+                this cross-origin (the session cookie auto-rides) but cannot
+                *read* the response or the new cookie (CORS), so they never learn
+                the token; and the self-heal guard returns the existing token
+                unchanged when it's already valid, so a triggered call never
+                rotates a healthy token.
+            """
+            if sessions.csrf_storage is None:
+                raise BadRequestException("CSRF is disabled.")
+            session_id = request.cookies.get(sessions.session_cookie_name)
+            session = await sessions.validate_session(session_id) if session_id else None
+            if session is None or session_id is None:
+                raise UnauthorizedException("Not authenticated")
+            cookie = request.cookies.get(sessions.csrf_cookie_name)
+            if cookie and await sessions.validate_csrf_token(session_id, cookie):
+                token = cookie
+            else:
+                token = await sessions.regenerate_csrf_token(session.user_id, session_id)
+                max_age = (
+                    sessions.timeout_seconds_for(session.metadata)
+                    if session.metadata.get(REMEMBER_ME_META_KEY)
+                    else None
+                )
+                sessions.set_csrf_cookie(response, token, max_age=max_age)
+            return {"csrf_token": token}
 
     # --- assembled routers ---------------------------------------------------
     @property

--- a/crudauth/crud_auth.py
+++ b/crudauth/crud_auth.py
@@ -82,10 +82,21 @@ class _ChangePasswordIn(BaseModel):
 
 
 class SessionInfo(BaseModel):
-    """One active session, as returned by ``GET /sessions``.
+    """One active session, as returned by ``GET /sessions`` (the opt-in management route).
 
     ``device`` is the parsed user-agent info (browser/os/device flags), empty when
     UA parsing isn't available; timestamps serialize to ISO-8601.
+
+    Example:
+        ```python
+        # each entry in the GET /sessions response:
+        SessionInfo(
+            session_id="9f3c...",
+            device={"browser": "Chrome", "os": "macOS", "is_mobile": False},
+            ip="203.0.113.7",
+            created_at=created, last_activity=seen, current=True,
+        )
+        ```
     """
 
     session_id: str

--- a/crudauth/hooks.py
+++ b/crudauth/hooks.py
@@ -55,6 +55,7 @@ class AuthHooks:
     on_after_logout: Hook | None = None
     on_after_recovery_verified: Hook | None = None
     on_after_password_reset: Hook | None = None
+    on_after_password_changed: Hook | None = None
     on_after_email_changed: Hook | None = None
     on_after_sudo: Hook | None = None
 
@@ -79,6 +80,12 @@ class AuthHooks:
     async def run_after_password_reset(self, user: dict, *, db: Any, context: HookContext) -> None:
         if self.on_after_password_reset is not None:
             await _maybe_await(self.on_after_password_reset(user, db=db, context=context))
+
+    async def run_after_password_changed(
+        self, user: dict, *, db: Any, context: HookContext
+    ) -> None:
+        if self.on_after_password_changed is not None:
+            await _maybe_await(self.on_after_password_changed(user, db=db, context=context))
 
     async def run_after_email_changed(self, user: dict, *, db: Any, context: HookContext) -> None:
         if self.on_after_email_changed is not None:

--- a/crudauth/ratelimit/config.py
+++ b/crudauth/ratelimit/config.py
@@ -48,4 +48,7 @@ DEFAULT_RATE_LIMITS: dict[str, RateLimit] = {
     "password_reset_request": RateLimit(times=5, seconds=SECONDS_PER_HOUR),
     "email_change_request": RateLimit(times=3, seconds=SECONDS_PER_HOUR),
     "existing_account_notice": RateLimit(times=5, seconds=SECONDS_PER_HOUR),
+    "change_password": RateLimit(times=5, seconds=SECONDS_PER_HOUR),
+    "logout_all": RateLimit(times=10, seconds=SECONDS_PER_HOUR),
+    "csrf_refresh": RateLimit(times=30, seconds=SECONDS_PER_HOUR),
 }

--- a/crudauth/transports/session/manager.py
+++ b/crudauth/transports/session/manager.py
@@ -358,16 +358,30 @@ class SessionManager:
             path=self.cookie_path,
             max_age=max_age,
         )
-        if csrf_token:
-            response.set_cookie(
-                key=self.csrf_cookie_name,
-                value=csrf_token,
-                httponly=False,
-                secure=self.cookie_secure,
-                samesite=self.cookie_samesite,
-                path=self.cookie_path,
-                max_age=max_age,
-            )
+        self.set_csrf_cookie(response, csrf_token, max_age=max_age)
+
+    def set_csrf_cookie(
+        self, response: Response, csrf_token: str, max_age: int | None = None
+    ) -> None:
+        """Write just the CSRF cookie (used on its own by the ``/csrf/refresh`` recovery path).
+
+        Note:
+            NOT ``httponly`` - the CSRF cookie must be readable by JS so the SPA
+            can echo it in the ``X-CSRF-Token`` header (the synchronizer-token
+            check). Same ``secure``/``samesite``/``path`` as the session cookie so
+            the pair can't disagree. A falsy ``csrf_token`` is a no-op.
+        """
+        if not csrf_token:
+            return
+        response.set_cookie(
+            key=self.csrf_cookie_name,
+            value=csrf_token,
+            httponly=False,
+            secure=self.cookie_secure,
+            samesite=self.cookie_samesite,
+            path=self.cookie_path,
+            max_age=max_age,
+        )
 
     def clear_session_cookies(self, response: Response) -> None:
         """Delete the session + CSRF cookies.

--- a/crudauth/transports/session/transport.py
+++ b/crudauth/transports/session/transport.py
@@ -67,6 +67,10 @@ class SessionTransport(Transport):
             per-IP key identifies an individual client, not a shared NAT/CGNAT
             egress). Governs the shared lockout (both ``/login`` and ``/token``).
             See [LockoutPolicy][crudauth.ratelimit.policy.LockoutPolicy].
+        management_routes: When ``True``, mount the opt-in session/CSRF management
+            routes on the shared router: ``POST /logout-all``, ``GET /sessions``,
+            ``DELETE /sessions/{id}``, and ``POST /csrf/refresh``. Default ``False``
+            (adding routes is a choice, and a device list isn't universally wanted).
 
     Example:
         ```python
@@ -95,6 +99,7 @@ class SessionTransport(Transport):
         login_lockout_base_seconds: int = DEFAULT_LOGIN_LOCKOUT_BASE_SECONDS,
         login_lockout_max_seconds: int = DEFAULT_LOGIN_LOCKOUT_MAX_SECONDS,
         on_login_success: Literal["clear_all", "clear_user_only"] = "clear_all",
+        management_routes: bool = False,
     ):
         self.backend = backend
         self.redis_url = redis_url
@@ -109,6 +114,7 @@ class SessionTransport(Transport):
         self.login_lockout_base_seconds = login_lockout_base_seconds
         self.login_lockout_max_seconds = login_lockout_max_seconds
         self.on_login_success = on_login_success
+        self.management_routes = management_routes
         self.manager: SessionManager | None = None
 
     # --- wiring --------------------------------------------------------------

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1,0 +1,88 @@
+# Endpoints
+
+Every HTTP route CRUDAuth can mount, in one place. You get them by including the router:
+
+```python
+app.include_router(auth.router)
+```
+
+Which routes appear depends on your config (transports, `email=`, `oauth=`, `management_routes`). For
+the full behavior of each flow, follow the guide links; this page is the at-a-glance map.
+
+**Auth column:** *none* = unauthenticated allowed; *any* = any authenticated transport; *session* =
+a session principal (CSRF enforced on unsafe verbs); *authenticated* = any transport (CSRF automatic
+on the session path, none on bearer).
+
+## Always mounted
+
+Present whenever `auth.router` is included, regardless of transports.
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| POST | `/register` | none | Create an account. Strict field allowlist. ([Registration](../guides/accounts/registration.md)) |
+| GET | `/me` | any | The authenticated user's id, scopes, and transport. |
+| POST | `/set-password` | authenticated | First password for an OAuth-only account; `400` if one already exists. ([Passwords](../guides/accounts/passwords.md#setting-a-password-on-an-oauth-only-account)) |
+| POST | `/change-password` | authenticated | Change a known password; `401` wrong current, `400` if unusable. Bumps `token_version`, revokes other sessions. ([Passwords](../guides/accounts/passwords.md#changing-a-known-password)) |
+
+## Session transport
+
+Mounted by `SessionTransport` (the default). ([Sessions](../guides/auth/sessions.md))
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| POST | `/login` | none | Form `username`+`password`; sets cookies, returns `{"csrf_token"}`. |
+| POST | `/logout` | session | Ends the current session, clears cookies. |
+
+### With `management_routes=True`
+
+Opt-in device/CSRF management. ([Devices & sessions](../guides/accounts/session-management.md), [recipe](../cookbook/account-management.md))
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| GET | `/sessions` | session | List active sessions ([`SessionInfo[]`](transports.md#sessioninfo)); `current` flags the caller. |
+| DELETE | `/sessions/{session_id}` | session | Revoke one (ownership-checked; `404` if not found or not yours). |
+| POST | `/logout-all` | session | Revoke all; `?keep_current=true` keeps the caller's. |
+| POST | `/csrf/refresh` | session cookie | Re-mint the CSRF cookie (no CSRF header required; self-heals; `400` if CSRF disabled, `401` if no session). |
+
+## Bearer transport
+
+Mounted by `BearerTransport`. ([Bearer tokens](../guides/auth/bearer.md))
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| POST | `/token` | none | Form login → `{"access_token", "token_type"}` (+ `refresh_token` when `refresh="body"`). |
+| POST | `/refresh` | refresh token | Mint a new access token (cookie rides automatically, or `{"refresh_token"}` body). |
+
+## Email & recovery
+
+Mounted when `email=` and/or `channels=` is set with a recovery factor. The verify/reset request
+bodies are shaped to the factor (`{"email": ...}` or `{"phone": ...}`). ([Email flows](../guides/accounts/email.md))
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| POST | `/email/verify-request` | none | Send a verification link/code. Non-enumerable (uniform response). |
+| POST | `/email/verify-confirm` | none | `{"token"}` → marks the recovery factor verified. |
+| POST | `/password/reset-request` | none | Send a reset link/code. Non-enumerable. |
+| POST | `/password/reset-confirm` | none | `{"token", "new_password"}`; evicts the user's other sessions. |
+| POST | `/email/change-request` | authenticated | `{"new_email", "password"}`. Mounted only when the model has an `email` column. |
+| POST | `/email/change-confirm` | none | `{"token"}` → applies the new address. |
+
+## OAuth
+
+Mounted per provider in `oauth={...}` (needs a `SessionTransport` + `redirect_base_url`). ([OAuth](../guides/auth/oauth.md))
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| GET | `/oauth/{provider}/authorize` | none | Start the flow; `?redirect_to=` (same-origin relative) for the post-login landing. |
+| GET | `/oauth/{provider}/callback` | none | Finish the flow, link/create the user, establish a session. |
+
+## Not a mounted route: sudo
+
+Sudo elevation is a primitive plus a gate, not an endpoint. Build your own `POST /sudo` calling
+`auth.sudo.elevate(...)`, and gate sensitive routes with `auth.require_sudo()`. ([Sudo mode](../guides/auth/sudo.md))
+
+## Mounting a subset
+
+You don't have to mount everything. `auth.session_router` and `auth.bearer_router` expose just that
+transport's routes, and `auth.current_user()` works on your own routes whether or not you mount any of
+CRUDAuth's.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,6 +11,7 @@ otherwise, each is importable straight from the top-level `crudauth` package.
 
 | Page | What's in it |
 |---|---|
+| [Endpoints](endpoints.md) | Every HTTP route CRUDAuth can mount, by area, and what gates each. |
 | [CRUDAuth](crud-auth.md) | The composition root. Configure transports, mount routers, and build the `current_user()` / `rate_limit()` / `require_sudo()` route guards. |
 | [Principal](principal.md) | The identity object every transport returns. |
 | [Core types](core.md) | `CookieConfig`, `AuthContext`, `AuthRuntime`. |

--- a/docs/api/transports.md
+++ b/docs/api/transports.md
@@ -21,3 +21,9 @@ Server-side sessions, CSRF, device management, and login lockout. Reachable as
 `auth.sessions` when a `SessionTransport` is configured.
 
 ::: crudauth.transports.session.manager.SessionManager
+
+## SessionInfo
+
+The response shape of `GET /sessions` (mounted by `SessionTransport(management_routes=True)`).
+
+::: crudauth.SessionInfo

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,29 @@ breaking changes; those are called out explicitly.
 
 ___
 
+## 0.5.0 - 2026-06-21
+
+Account & device management. The session/device endpoints apps kept hand-writing are now opt-in
+built-in routes, plus an in-session password change. Everything is additive.
+
+#### Added
+- **Session & CSRF management routes** (`SessionTransport(management_routes=True)`, off by default):
+  `GET /sessions` (device list), `DELETE /sessions/{id}` (revoke one, ownership-checked, `404` if not
+  found or not yours), `POST /logout-all` (with `?keep_current=true`), and `POST /csrf/refresh`
+  (re-mint a lost CSRF cookie; self-heals; the deliberate non-`current_user` recovery path). Thin
+  handlers over the existing `SessionManager`; the three mutating ones enforce CSRF via the session
+  transport.
+- **`POST /change-password`** (always mounted): change a known password while signed in. The current
+  password is the re-authentication; a successful change bumps `token_version` and revokes the user's
+  *other* sessions (keeping the current one), and fires `on_after_password_changed`. `401` on a wrong
+  current password, `400` on an OAuth-only account (use `/set-password`).
+- **`on_after_password_changed`** hook, distinct from `on_after_password_reset` (the token flow).
+- **`SessionInfo`** is now exported (the `GET /sessions` response model), and a flat **Endpoints**
+  API-reference page maps every mountable route in one place.
+- `SessionManager.set_csrf_cookie(...)` (the CSRF half of `set_session_cookies`, reusable on its own).
+
+___
+
 ## 0.4.0 - 2026-06-21
 
 Custom email bodies. `EmailSender.send` now receives an `EmailContext`, so you render your own

--- a/docs/cookbook/account-management.md
+++ b/docs/cookbook/account-management.md
@@ -1,0 +1,105 @@
+# Account & device management
+
+Most apps grow a settings page: "where am I signed in," sign out a single device, sign out
+everywhere, change my password. crudauth ships these as opt-in routes, so you wire buttons to them
+instead of hand-writing session bookkeeping, CSRF refresh, and an in-session password change. The
+security parts (CSRF, ownership checks, session eviction) are already handled.
+
+This recipe assumes the [email and password](email-password.md) base (a session transport, a mounted
+router).
+
+## 1. Turn the routes on
+
+The session and CSRF routes are opt-in; flip `management_routes=True` on the `SessionTransport`.
+`/change-password` is always present (it's a core flow), so it needs no flag.
+
+```python title="main.py"
+from crudauth import CRUDAuth, SessionTransport
+from myapp.db import get_session
+from myapp.models import User
+
+auth = CRUDAuth(
+    session=get_session, user_model=User, SECRET_KEY="change-me",
+    transports=[SessionTransport(management_routes=True)],
+)
+app.include_router(auth.router)
+```
+
+That mounts `GET /sessions`, `DELETE /sessions/{id}`, `POST /logout-all`, and `POST /csrf/refresh`,
+alongside the always-on `POST /change-password`.
+
+## 2. The device list
+
+`GET /sessions` returns one entry per active session, with parsed device info and a `current` flag
+for the calling session, so a "your devices" table is a single fetch:
+
+```bash
+curl http://localhost:8000/sessions -b jar.txt
+# [{"session_id":"...","device":{"browser":"Chrome","os":"macOS",...},
+#   "ip":"...","created_at":"...","last_activity":"...","current":true}, ...]
+```
+
+## 3. Revoke a device, or sign out everywhere
+
+`DELETE /sessions/{id}` revokes one session; it's ownership-checked, so a user can only drop their
+own, and an id that isn't theirs (or doesn't exist) is a `404` with no leak. `POST /logout-all` drops
+them all, with `?keep_current=true` for the common "sign out my other devices":
+
+```bash
+# revoke one device (CSRF header required on the unsafe verb)
+curl -X DELETE http://localhost:8000/sessions/<id> -b jar.txt -H "X-CSRF-Token: <token>"
+
+# sign out everywhere except here
+curl -X POST "http://localhost:8000/logout-all?keep_current=true" -b jar.txt -H "X-CSRF-Token: <token>"
+# {"detail": "Signed out of all sessions.", "revoked": 3}
+```
+
+Revoking your own current session (or `/logout-all` without `keep_current`) clears the session
+cookies on the way out.
+
+## 4. Change a password
+
+`POST /change-password` verifies the current password and sets the new one. The current password is
+the re-authentication, so there's no email round-trip:
+
+```bash
+curl -X POST http://localhost:8000/change-password -b jar.txt -H "X-CSRF-Token: <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"current_password":"old-one","new_password":"a-new-strong-one"}'
+```
+
+A wrong current password is `401`; an OAuth-only account (no usable password) is `400` and should use
+[`/set-password`](../guides/accounts/passwords.md#setting-a-password-on-an-oauth-only-account). A
+successful change is treated as a compromise response: it bumps `token_version` (evicting bearer
+tokens) and revokes the user's *other* sessions, keeping the current one, and fires the
+`on_after_password_changed` hook (a good place for a "your password was changed" email).
+
+## 5. Self-heal a lost CSRF cookie
+
+An SPA can lose its CSRF cookie (a cleared cookie jar, a stale tab) while the session cookie is still
+valid, which would make every mutation fail. `POST /csrf/refresh` re-mints it:
+
+```bash
+curl -X POST http://localhost:8000/csrf/refresh -b jar.txt
+# {"csrf_token": "..."}  (+ a fresh CSRF cookie)
+```
+
+It deliberately doesn't require a CSRF header (that would defeat the recovery), resolves the session
+cookie directly, and self-heals: if the current CSRF cookie is already valid it returns it unchanged
+rather than rotating. An attacker can trigger it cross-origin but can't read the response (CORS), so
+they never learn the token.
+
+## Why this is safe to expose
+
+Each route is thin: authenticate, validate, call an existing `SessionManager` method. The dangerous
+parts are handled for you, not left to your handler. CSRF is enforced on the unsafe verbs because they
+sit behind a session principal (the one recovery exception, `/csrf/refresh`, is documented above).
+`DELETE /sessions/{id}` is ownership-checked and returns `404` for both "not found" and "not yours,"
+so it can't be used to probe other users' session ids. And a password change evicts other credentials
+while keeping the caller signed in. You wire the buttons; the invariants come with the routes.
+
+## Where to go next
+
+- The manual approach (build your own routes over `auth.sessions`): [Devices & sessions](../guides/accounts/session-management.md).
+- The password flows in full: [Passwords](../guides/accounts/passwords.md).
+- Going to production (Redis-backed sessions so the device list is shared across workers): [Going to production](going-to-production.md).

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -95,6 +95,15 @@ so you can copy one and have the account shape you want.
 
     [Read →](going-to-production.md)
 
+-   **[Account & device management](account-management.md)**
+
+    ---
+
+    A settings page from opt-in routes: list devices, sign out one or all, change password,
+    self-heal a lost CSRF cookie.
+
+    [Read →](account-management.md)
+
 </div>
 
 **Prerequisites:** a FastAPI app and an async SQLAlchemy 2.0 session dependency. Each recipe

--- a/docs/guides/accounts/passwords.md
+++ b/docs/guides/accounts/passwords.md
@@ -49,6 +49,25 @@ This is **set**, not change: it refuses with `400` if the account already has a 
 password (use the reset flow to change an existing one), and it doesn't evict other sessions,
 because establishing a first credential isn't a compromise response.
 
+## Changing a known password
+
+A signed-in user with a password changes it through `POST /change-password`, a built-in route. The
+current password is the re-authentication (the active session/token proves presence, the current
+password proves intent), so no token round-trip is needed.
+
+```bash
+curl -X POST http://localhost:8000/change-password \
+  -H "X-CSRF-Token: <token>" -H "Content-Type: application/json" \
+  -b "session_id=<cookie>" \
+  -d '{"current_password": "old-one", "new_password": "a-new-strong-one"}'
+```
+
+Allowed over any transport: CSRF is automatic on the session path, and bearer has no CSRF surface.
+A wrong current password is a `401`; an account with no usable password is a `400` (use
+`/set-password` instead). Because a password change is a compromise response, it bumps
+`token_version` (evicting bearer tokens) and revokes the user's *other* sessions, keeping the
+current one, and fires the `on_after_password_changed` hook.
+
 ## Resetting a forgotten password
 
 A user who can't log in uses the email reset flow: `POST /password/reset-request` sends a

--- a/docs/guides/accounts/session-management.md
+++ b/docs/guides/accounts/session-management.md
@@ -3,18 +3,37 @@
 Every login is a separate server-side session, so you can show users where they're signed in
 and let them sign out of one device or all of them.
 
-These aren't built-in routes. CRUDAuth exposes the session manager as `auth.sessions`
-whenever a `SessionTransport` is configured (the default), and you add the endpoints your UI
-needs on top of it:
+## Built-in routes (opt-in)
+
+Pass `management_routes=True` to the `SessionTransport` and CRUDAuth mounts the device-management
+routes for you:
 
 ```python
-auth = CRUDAuth(session=get_session, user_model=User, SECRET_KEY="change-me")  # SessionTransport by default
+auth = CRUDAuth(
+    session=get_session, user_model=User, SECRET_KEY="change-me",
+    transports=[SessionTransport(management_routes=True)],
+)
 app.include_router(auth.router)
-# auth.sessions.list_for_user / revoke / revoke_all are now available
 ```
 
-See [Getting started](../../getting-started.md) for the base app. The examples below are
-routes you add to your own `app`.
+| Route | What it does |
+|---|---|
+| `GET /sessions` | list the user's active sessions (`SessionInfo[]`; `current` flags the caller's) |
+| `DELETE /sessions/{id}` | revoke one session (ownership-checked; 404 if not found or not yours) |
+| `POST /logout-all` | revoke all sessions; `?keep_current=true` keeps the calling one |
+| `POST /csrf/refresh` | re-mint the CSRF cookie when it's lost but the session is still valid |
+
+All but `/csrf/refresh` run behind a session principal, so the unsafe verbs are CSRF-protected
+automatically. `/csrf/refresh` is the deliberate exception: it resolves the session cookie directly
+(requiring a valid CSRF header to *refresh* CSRF would defeat the recovery purpose) and self-heals,
+returning the existing token unchanged when it's already valid. The routes are opt-in (`False` by
+default) because adding endpoints and a device list isn't universally wanted.
+
+## Rolling your own
+
+If you need a different shape, CRUDAuth exposes the session manager as `auth.sessions` whenever a
+`SessionTransport` is configured, and you build the endpoints your UI needs on top of it. The
+examples below are routes you add to your own `app`.
 
 ## List a user's sessions
 

--- a/docs/guides/infra/hooks.md
+++ b/docs/guides/infra/hooks.md
@@ -26,6 +26,7 @@ your hooks don't couple to the model.
 | `on_after_logout` | a logout | `user, request, context` |
 | `on_after_recovery_verified` | recovery-factor verification confirm | `user, db, context` |
 | `on_after_password_reset` | password reset confirm | `user, db, context` |
+| `on_after_password_changed` | in-session password change (`/change-password`) | `user, db, context` |
 | `on_after_email_changed` | email change confirm | `user, db, context` |
 | `on_after_sudo` | a sudo elevation | `user, request, context` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crudauth"
-version = "0.4.0"
+version = "0.5.0"
 description = "Batteries-included, transport-agnostic authentication for FastAPI."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_change_password.py
+++ b/tests/test_change_password.py
@@ -1,0 +1,146 @@
+"""POST /change-password: in-session change with the current password, evicting other credentials.
+
+Unconditional (sibling of /set-password). Re-auth is the current password; a successful change bumps
+token_version and revokes the user's other sessions, keeping the current one."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import httpx
+from fastapi import FastAPI
+
+from crudauth import AuthHooks, CookieConfig, CRUDAuth, SessionTransport
+from crudauth.repository import UserRepository
+from crudauth.utils import make_unusable_password
+
+SECRET = "test-secret-key-0123456789-0123456789"
+
+
+def _build(get_session, UserModel, hooks=None):
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=UserModel,
+        SECRET_KEY=SECRET,
+        transports=[SessionTransport(cookies=CookieConfig(secure=False))],
+        hooks=hooks or AuthHooks(),
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+    return app, auth
+
+
+@asynccontextmanager
+async def _client(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+async def _register_login(c):
+    await c.post(
+        "/register", json={"email": "a@x.com", "username": "alice", "password": "pw123456"}
+    )
+    r = await c.post("/login", data={"username": "alice", "password": "pw123456"})
+    return r.json()["csrf_token"]
+
+
+async def test_wrong_current_password_401(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as c:
+        csrf = await _register_login(c)
+        r = await c.post(
+            "/change-password",
+            headers={"X-CSRF-Token": csrf},
+            json={"current_password": "not-it", "new_password": "new-strong-1"},
+        )
+        assert r.status_code == 401
+    await auth.shutdown()
+
+
+async def test_unusable_password_400(get_session, UserModel, sessionmaker) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as c:
+        csrf = await _register_login(c)
+        repo = UserRepository(UserModel)
+        async with sessionmaker() as db:  # flip the stored hash to unusable (OAuth-only shape)
+            user = await repo.get_by_email(db, "a@x.com")
+            await repo.update(db, user, {"hashed_password": make_unusable_password()})
+        r = await c.post(
+            "/change-password",
+            headers={"X-CSRF-Token": csrf},
+            json={"current_password": "pw123456", "new_password": "new-strong-1"},
+        )
+        assert r.status_code == 400  # points at /set-password
+    await auth.shutdown()
+
+
+async def test_change_password_success_rotates_evicts_and_fires_hook(
+    get_session, UserModel, sessionmaker
+) -> None:
+    fired: list[dict] = []
+    hooks = AuthHooks(on_after_password_changed=lambda user, **kw: fired.append(user))
+    app, auth = _build(get_session, UserModel, hooks=hooks)
+    await auth.initialize()
+    async with _client(app) as a, _client(app) as b:
+        csrf_a = await _register_login(a)
+        # second session for the same user (its own jar)
+        r = await b.post("/login", data={"username": "alice", "password": "pw123456"})
+        assert r.status_code == 200
+
+        r = await a.post(
+            "/change-password",
+            headers={"X-CSRF-Token": csrf_a},
+            json={"current_password": "pw123456", "new_password": "new-strong-1"},
+        )
+        assert r.status_code == 200
+
+        assert len(fired) == 1  # on_after_password_changed fired once
+        assert (await b.get("/me")).status_code == 401  # other session evicted
+        assert (await a.get("/me")).status_code == 200  # caller's session kept
+
+        repo = UserRepository(UserModel)
+        async with sessionmaker() as db:
+            user = await repo.get_by_email(db, "a@x.com")
+            assert repo.token_version(user) == 1  # bumped (evicts bearer tokens)
+
+    # the hash actually rotated: new password logs in, old does not
+    async with _client(app) as fresh:
+        assert (
+            await fresh.post("/login", data={"username": "alice", "password": "new-strong-1"})
+        ).status_code == 200
+        assert (
+            await fresh.post("/login", data={"username": "alice", "password": "pw123456"})
+        ).status_code == 401
+    await auth.shutdown()
+
+
+async def test_change_password_requires_csrf_on_session(get_session, UserModel) -> None:
+    # CSRF is auto-enforced on the session path (the spec's "free CSRF" claim):
+    # a mutation behind current_user() without the X-CSRF-Token header is a 403.
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as c:
+        await _register_login(c)  # session + csrf cookie in the jar; header deliberately omitted
+        r = await c.post(
+            "/change-password",
+            json={"current_password": "pw123456", "new_password": "new-strong-1"},
+        )
+        assert r.status_code == 403
+    await auth.shutdown()
+
+
+async def test_change_password_rate_limited(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as c:
+        csrf = await _register_login(c)
+        body = {"current_password": "wrong", "new_password": "new-strong-1"}
+        for _ in range(5):  # the change_password default is 5/hour, keyed by user
+            await c.post("/change-password", headers={"X-CSRF-Token": csrf}, json=body)
+        r = await c.post("/change-password", headers={"X-CSRF-Token": csrf}, json=body)
+        assert r.status_code == 429
+    await auth.shutdown()

--- a/tests/test_change_password.py
+++ b/tests/test_change_password.py
@@ -99,8 +99,10 @@ async def test_change_password_success_rotates_evicts_and_fires_hook(
         assert r.status_code == 200
 
         assert len(fired) == 1  # on_after_password_changed fired once
-        assert (await b.get("/me")).status_code == 401  # other session evicted
-        assert (await a.get("/me")).status_code == 200  # caller's session kept
+        resp = await b.get("/me")
+        assert resp.status_code == 401  # other session evicted
+        resp = await a.get("/me")
+        assert resp.status_code == 200  # caller's session kept
 
         repo = UserRepository(UserModel)
         async with sessionmaker() as db:
@@ -109,12 +111,10 @@ async def test_change_password_success_rotates_evicts_and_fires_hook(
 
     # the hash actually rotated: new password logs in, old does not
     async with _client(app) as fresh:
-        assert (
-            await fresh.post("/login", data={"username": "alice", "password": "new-strong-1"})
-        ).status_code == 200
-        assert (
-            await fresh.post("/login", data={"username": "alice", "password": "pw123456"})
-        ).status_code == 401
+        resp = await fresh.post("/login", data={"username": "alice", "password": "new-strong-1"})
+        assert resp.status_code == 200
+        resp = await fresh.post("/login", data={"username": "alice", "password": "pw123456"})
+        assert resp.status_code == 401
     await auth.shutdown()
 
 

--- a/tests/transports/test_management_routes.py
+++ b/tests/transports/test_management_routes.py
@@ -1,0 +1,165 @@
+"""Opt-in session/CSRF management routes: /logout-all, /sessions, DELETE /sessions/{id}, /csrf/refresh.
+
+Mounted only by SessionTransport(management_routes=True). All run behind a session principal except
+/csrf/refresh (the recovery path, which resolves the session cookie directly)."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import httpx
+from fastapi import FastAPI
+
+from crudauth import CRUDAuth, CookieConfig, SessionTransport
+
+SECRET = "test-secret-key-0123456789-0123456789"
+
+
+def _build(get_session, UserModel, *, management_routes=True, csrf=True):
+    auth = CRUDAuth(
+        session=get_session,
+        user_model=UserModel,
+        SECRET_KEY=SECRET,
+        transports=[
+            SessionTransport(
+                cookies=CookieConfig(secure=False), management_routes=management_routes, csrf=csrf
+            )
+        ],
+    )
+    app = FastAPI()
+    app.include_router(auth.router)
+    return app, auth
+
+
+@asynccontextmanager
+async def _client(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+async def _register_login(c, username="alice", email=None):
+    email = email or f"{username}@x.com"
+    await c.post("/register", json={"email": email, "username": username, "password": "pw123456"})
+    r = await c.post("/login", data={"username": username, "password": "pw123456"})
+    return r.json()["csrf_token"]
+
+
+async def test_routes_gated_off_by_default(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel, management_routes=False)
+    await auth.initialize()
+    async with _client(app) as c:
+        await _register_login(c)
+        assert (await c.get("/sessions")).status_code == 404  # not mounted
+    await auth.shutdown()
+
+
+async def test_logout_all_revokes_and_clears(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as c:
+        csrf = await _register_login(c)
+        r = await c.post("/logout-all", headers={"X-CSRF-Token": csrf})
+        assert r.status_code == 200
+        assert r.json()["revoked"] >= 1
+        assert (await c.get("/me")).status_code == 401  # cookie cleared, session gone
+    await auth.shutdown()
+
+
+async def test_logout_all_keep_current(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as a, _client(app) as b:
+        csrf_a = await _register_login(a)
+        await _register_login(b)  # second session for the same user
+        r = await a.post("/logout-all?keep_current=true", headers={"X-CSRF-Token": csrf_a})
+        assert r.status_code == 200 and r.json()["revoked"] == 1  # revoked B, kept A
+        assert (await a.get("/me")).status_code == 200  # caller's session survives
+        assert (await b.get("/me")).status_code == 401  # the other session is gone
+    await auth.shutdown()
+
+
+async def test_sessions_list_shape_and_current_flag(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as c:
+        await _register_login(c)
+        rows = (await c.get("/sessions")).json()
+        assert len(rows) == 1
+        s = rows[0]
+        assert set(s) >= {"session_id", "device", "ip", "created_at", "last_activity", "current"}
+        assert s["current"] is True
+    await auth.shutdown()
+
+
+async def test_delete_own_other_unknown_and_cross_user(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as a, _client(app) as b, _client(app) as other:
+        csrf_a = await _register_login(a, "alice")
+        await _register_login(b, "alice")  # alice's 2nd session
+        csrf_other = await _register_login(other, "bob")  # different user
+
+        sessions = (await a.get("/sessions")).json()
+        b_id = next(s["session_id"] for s in sessions if not s["current"])
+        a_id = next(s["session_id"] for s in sessions if s["current"])
+
+        # revoke alice's other session (B)
+        r = await a.delete(f"/sessions/{b_id}", headers={"X-CSRF-Token": csrf_a})
+        assert r.status_code == 200
+        assert (await b.get("/me")).status_code == 401
+
+        # unknown id -> 404
+        assert (
+            await a.delete("/sessions/nope", headers={"X-CSRF-Token": csrf_a})
+        ).status_code == 404
+
+        # another user's session id -> 404 (ownership check, no leak)
+        assert (
+            await other.delete(f"/sessions/{a_id}", headers={"X-CSRF-Token": csrf_other})
+        ).status_code == 404
+        assert (await a.get("/me")).status_code == 200  # untouched
+
+        # revoke own current session -> 200 + cookie cleared
+        r = await a.delete(f"/sessions/{a_id}", headers={"X-CSRF-Token": csrf_a})
+        assert r.status_code == 200
+        assert (await a.get("/me")).status_code == 401
+    await auth.shutdown()
+
+
+async def test_csrf_refresh_self_heal_and_rotate(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    csrf_name = auth.sessions.csrf_cookie_name
+    async with _client(app) as c:
+        csrf = await _register_login(c)
+        # valid cookie -> same token, no rotation (self-heal)
+        r = await c.post("/csrf/refresh")
+        assert r.status_code == 200 and r.json()["csrf_token"] == csrf
+
+        # drop the csrf cookie -> new token minted + Set-Cookie
+        del c.cookies[csrf_name]
+        r = await c.post("/csrf/refresh")
+        assert r.status_code == 200
+        new = r.json()["csrf_token"]
+        assert new and new != ""
+        assert csrf_name in r.headers.get("set-cookie", "")
+    await auth.shutdown()
+
+
+async def test_csrf_refresh_no_session_401(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel)
+    await auth.initialize()
+    async with _client(app) as c:
+        assert (await c.post("/csrf/refresh")).status_code == 401  # no session cookie
+    await auth.shutdown()
+
+
+async def test_csrf_refresh_disabled_400(get_session, UserModel) -> None:
+    app, auth = _build(get_session, UserModel, csrf=False)
+    await auth.initialize()
+    async with _client(app) as c:
+        await _register_login(c)
+        assert (await c.post("/csrf/refresh")).status_code == 400  # CSRF disabled
+    await auth.shutdown()

--- a/tests/transports/test_management_routes.py
+++ b/tests/transports/test_management_routes.py
@@ -51,7 +51,8 @@ async def test_routes_gated_off_by_default(get_session, UserModel) -> None:
     await auth.initialize()
     async with _client(app) as c:
         await _register_login(c)
-        assert (await c.get("/sessions")).status_code == 404  # not mounted
+        resp = await c.get("/sessions")
+        assert resp.status_code == 404  # not mounted
     await auth.shutdown()
 
 
@@ -63,7 +64,8 @@ async def test_logout_all_revokes_and_clears(get_session, UserModel) -> None:
         r = await c.post("/logout-all", headers={"X-CSRF-Token": csrf})
         assert r.status_code == 200
         assert r.json()["revoked"] >= 1
-        assert (await c.get("/me")).status_code == 401  # cookie cleared, session gone
+        resp = await c.get("/me")
+        assert resp.status_code == 401  # cookie cleared, session gone
     await auth.shutdown()
 
 
@@ -75,8 +77,10 @@ async def test_logout_all_keep_current(get_session, UserModel) -> None:
         await _register_login(b)  # second session for the same user
         r = await a.post("/logout-all?keep_current=true", headers={"X-CSRF-Token": csrf_a})
         assert r.status_code == 200 and r.json()["revoked"] == 1  # revoked B, kept A
-        assert (await a.get("/me")).status_code == 200  # caller's session survives
-        assert (await b.get("/me")).status_code == 401  # the other session is gone
+        resp = await a.get("/me")
+        assert resp.status_code == 200  # caller's session survives
+        resp = await b.get("/me")
+        assert resp.status_code == 401  # the other session is gone
     await auth.shutdown()
 
 
@@ -108,23 +112,24 @@ async def test_delete_own_other_unknown_and_cross_user(get_session, UserModel) -
         # revoke alice's other session (B)
         r = await a.delete(f"/sessions/{b_id}", headers={"X-CSRF-Token": csrf_a})
         assert r.status_code == 200
-        assert (await b.get("/me")).status_code == 401
+        resp = await b.get("/me")
+        assert resp.status_code == 401
 
         # unknown id -> 404
-        assert (
-            await a.delete("/sessions/nope", headers={"X-CSRF-Token": csrf_a})
-        ).status_code == 404
+        resp = await a.delete("/sessions/nope", headers={"X-CSRF-Token": csrf_a})
+        assert resp.status_code == 404
 
         # another user's session id -> 404 (ownership check, no leak)
-        assert (
-            await other.delete(f"/sessions/{a_id}", headers={"X-CSRF-Token": csrf_other})
-        ).status_code == 404
-        assert (await a.get("/me")).status_code == 200  # untouched
+        resp = await other.delete(f"/sessions/{a_id}", headers={"X-CSRF-Token": csrf_other})
+        assert resp.status_code == 404
+        resp = await a.get("/me")
+        assert resp.status_code == 200  # untouched
 
         # revoke own current session -> 200 + cookie cleared
         r = await a.delete(f"/sessions/{a_id}", headers={"X-CSRF-Token": csrf_a})
         assert r.status_code == 200
-        assert (await a.get("/me")).status_code == 401
+        resp = await a.get("/me")
+        assert resp.status_code == 401
     await auth.shutdown()
 
 
@@ -152,7 +157,8 @@ async def test_csrf_refresh_no_session_401(get_session, UserModel) -> None:
     app, auth = _build(get_session, UserModel)
     await auth.initialize()
     async with _client(app) as c:
-        assert (await c.post("/csrf/refresh")).status_code == 401  # no session cookie
+        resp = await c.post("/csrf/refresh")
+        assert resp.status_code == 401  # no session cookie
     await auth.shutdown()
 
 
@@ -161,5 +167,6 @@ async def test_csrf_refresh_disabled_400(get_session, UserModel) -> None:
     await auth.initialize()
     async with _client(app) as c:
         await _register_login(c)
-        assert (await c.post("/csrf/refresh")).status_code == 400  # CSRF disabled
+        resp = await c.post("/csrf/refresh")
+        assert resp.status_code == 400  # CSRF disabled
     await auth.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "crudauth"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -130,6 +130,7 @@ edit_uri = "edit/main/docs/"
     { "Server-set fields at signup" = "cookbook/server-set-fields.md" },
     { "Onboard an existing users table" = "cookbook/existing-users-table.md" },
     { "Going to production" = "cookbook/going-to-production.md" },
+    { "Account & device management" = "cookbook/account-management.md" },
 ]
 
 [[project.nav]]

--- a/zensical.toml
+++ b/zensical.toml
@@ -136,6 +136,7 @@ edit_uri = "edit/main/docs/"
 [[project.nav]]
 "API Reference" = [
     { "Overview" = "api/index.md" },
+    { "Endpoints" = "api/endpoints.md" },
     { "CRUDAuth" = "api/crud-auth.md" },
     { "Principal" = "api/principal.md" },
     { "Identity" = "api/identity.md" },


### PR DESCRIPTION
# Account & device management: session/CSRF routes + in-session password change

Apps kept hand-writing the same four endpoints on top of `auth.sessions` (sign out everywhere, a
device list, revoke one device, refresh a lost CSRF cookie) and an in-session password change that
crudauth didn't offer at all. This branch exposes both as thin, opt-in routes that reuse existing
`SessionManager` and repository primitives, so there's no new auth/session/crypto logic, just
auth + validation + a call to a method that already exists. All additive: nothing breaks.

---

## Session & CSRF management routes (opt-in)

`auth.sessions` already had `list_for_user` / `revoke` / `revoke_all` / `regenerate_csrf_token`, but
no routes, so every app rebuilt the same handlers. A new `SessionTransport(management_routes=True)`
flag mounts four of them on the shared router: `GET /sessions`, `DELETE /sessions/{id}`,
`POST /logout-all` (with `?keep_current=true`), and `POST /csrf/refresh`. The flag lives on the
transport (where session config lives) but the routes are assembled centrally in `CRUDAuth`, gated on
`self._session_transport and management_routes`, because that's where `current_user()` and
`self.sessions` are. Default is `False`: adding routes and a device list to an existing app on a minor
bump should be a choice.

The three mutating routes sit behind `current_user(transport="session")`, so CSRF on the unsafe verbs
is enforced by the session transport, the handlers add none. `DELETE /sessions/{id}` is
ownership-checked and returns `404` for both "not found" and "not yours", so it can't probe other
users' session ids.

`POST /csrf/refresh` is the deliberate exception. It does **not** go through `current_user()` because
requiring a valid CSRF header to refresh CSRF would defeat the recovery purpose; it resolves the
session cookie directly and self-heals:

```python
if cookie and await sessions.validate_csrf_token(session_id, cookie):
    token = cookie                       # already valid -> return unchanged, no rotation
else:
    token = await sessions.regenerate_csrf_token(session.user_id, session_id)
    sessions.set_csrf_cookie(response, token, max_age=...)
```

**Why this is safe:** an attacker can *trigger* it cross-origin (the session cookie auto-rides) but
can't *read* the response or the new cookie (CORS), so they never learn the token; and the self-heal
guard means a triggered call against a healthy cookie returns it unchanged rather than rotating, so
there's no cross-origin DoS on a valid token.

This added one small primitive, `SessionManager.set_csrf_cookie(response, token, max_age=None)` (the
CSRF half of `set_session_cookies`, which now delegates to it), so the recovery path can re-mint the
CSRF cookie alone.

---

## In-session password change

crudauth had `/set-password` (first password for an OAuth-only account) but no way for a user who
*has* a password to change it while signed in. `POST /change-password` fills that, as a sibling of
`/set-password` and unconditional for the same reason (a core flow, harmless when present because it
requires auth plus the current password).

Re-auth is the current password: the active session or token proves presence, the current password
proves intent, so no sudo or token round-trip. A wrong current password is `401`; an account with no
usable password (OAuth-only) is `400` and pointed at `/set-password`. A successful change is treated
as a compromise response, matching what a password reset does: it bumps `token_version` (evicting
bearer tokens, a no-op when the model has no such column) and revokes the user's *other* sessions
while keeping the current one (`revoke_all(exclude=current_session_id)`), then fires a hook. CSRF is
free on the session path (the POST runs behind `current_user()`); bearer has no CSRF surface.

**Why the eviction:** "change my password, sign out my other devices, keep me here" is the behavior
users expect, and it degrades cleanly, no `token_version` column means bearer eviction is simply
skipped, no session transport means session eviction is skipped.

---

## Supporting additions

A new optional hook `AuthHooks.on_after_password_changed` (with its `run_after_password_changed`
runner) fires after `/change-password`, kept distinct from `on_after_password_reset` (the token flow)
so an app can send a "your password was changed" notice. `DEFAULT_RATE_LIMITS` gained `change_password`
(5/h, per user), `logout_all` (10/h, per user), and `csrf_refresh` (30/h, per IP, since it runs before
authentication). `SessionInfo` (the `GET /sessions` response model) is now exported from `crudauth`
with an `Example:`, and a flat `api/endpoints.md` reference now maps every mountable route in one place.

---

## Documentation Updates

**`docs/cookbook/account-management.md`** (new): a from-scratch "settings page" recipe wiring all five
routes, with a "why this is safe to expose" payoff.

**`docs/guides/accounts/session-management.md`:** leads with the opt-in built-in routes (table), keeps
the manual `auth.sessions` approach for custom UIs.

**`docs/guides/accounts/passwords.md`:** a "Changing a known password" section between set-password and
reset.

**`docs/guides/infra/hooks.md`:** the `on_after_password_changed` row.

**`docs/api/endpoints.md`** (new) + `api/transports.md` (`SessionInfo`) + `api/index.md` + nav.

---

## Test Plan

### Automated
- [x] `uv run ruff check crudauth tests` — clean
- [x] `uv run mypy crudauth tests --config-file pyproject.toml` — clean
- [x] `uv run pytest` — 316 passing (13 new; no regressions)
- [x] `uv run --group docs zensical build` — no issues

### Session & CSRF management routes (`tests/transports/test_management_routes.py`)
- [x] Routes 404 when `management_routes` is off (default)
- [x] `/logout-all` revokes all + clears cookies; `keep_current=true` keeps the caller's session and cookie, revokes only the others
- [x] `GET /sessions` shape + `current` flag
- [x] `DELETE /sessions/{id}`: own (200 + cookie cleared if current), another user's id → 404, unknown → 404
- [x] `/csrf/refresh`: valid cookie → same token (no rotation), missing cookie → new token + Set-Cookie, no session → 401, CSRF disabled → 400

### In-session password change (`tests/test_change_password.py`)
- [x] Wrong current → 401; unusable password → 400
- [x] Success rotates the hash (new logs in, old doesn't), bumps `token_version`, revokes other sessions but not the current, fires the hook
- [x] Session POST without the CSRF header → 403 (CSRF is enforced)
- [x] Rate-limited after 5 attempts → 429

---

## Dependencies

None new.

## Breaking Changes

None. Everything is additive: `management_routes` defaults to `False`, `/change-password` is a new
route, `on_after_password_changed` is a new optional hook field, `set_csrf_cookie` and `SessionInfo`
are new public symbols, and `set_session_cookies` is behavior-preserving (it now delegates the CSRF
cookie to `set_csrf_cookie`; the existing session suite passes unchanged).
